### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # be requested for review when someone opens a pull request.
 * @creativecommons/internal-tech
 * @creativecommons/ct-legal-database-core-committers
+* @creativecommons/ct-legal-database-maintainers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.