### PR TITLE
update npm packages

### DIFF
--- a/webpack/package-lock.json
+++ b/webpack/package-lock.json
@@ -77,18 +77,18 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -114,9 +114,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -293,9 +293,9 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "funding": [
         {
           "type": "opencollective",
@@ -388,10 +388,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -411,9 +411,9 @@
       "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001375",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
-      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -534,9 +534,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.213",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
-      "integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -1091,9 +1091,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1169,9 +1169,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1278,9 +1278,9 @@
       ]
     },
     "node_modules/sass": {
-      "version": "1.54.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
+      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -1294,9 +1294,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.3.1.tgz",
-      "integrity": "sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.4.1.tgz",
+      "integrity": "sha512-aX/iJZTTpNUNx/OSYzo2KsjIUQHqvWsAhhUijFjAPdZTEhstjZI9zTNvkTTwsx+uNUJqUwOw5gacxQMx4hJxGQ==",
       "dependencies": {
         "klona": "^2.0.4",
         "loader-utils": "^2.0.0",
@@ -1313,7 +1313,7 @@
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "sass": "^1.3.0",
         "webpack": "^4.36.0 || ^5.0.0"
       },
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -1498,15 +1498,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -1791,18 +1791,18 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
+      "integrity": "sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -1828,9 +1828,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -1994,9 +1994,9 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -2049,14 +2049,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "buffer-from": {
@@ -2070,9 +2070,9 @@
       "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001375",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
-      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw=="
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
     },
     "chokidar": {
       "version": "3.5.3",
@@ -2147,9 +2147,9 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "electron-to-chromium": {
-      "version": "1.4.213",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
-      "integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -2322,9 +2322,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -2406,9 +2406,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -2534,9 +2534,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -2576,9 +2576,9 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
+      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2647,9 +2647,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sass": {
-      "version": "1.54.4",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-      "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
+      "integrity": "sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -2657,9 +2657,9 @@
       }
     },
     "sass-loader": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.3.1.tgz",
-      "integrity": "sha512-y2aBdtYkbqorVavkC3fcJIUDGIegzDWPn3/LAFhsf3G+MzPKTJx37sROf5pXtUeggSVbNbmfj8TgRaSLMelXRA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.4.1.tgz",
+      "integrity": "sha512-aX/iJZTTpNUNx/OSYzo2KsjIUQHqvWsAhhUijFjAPdZTEhstjZI9zTNvkTTwsx+uNUJqUwOw5gacxQMx4hJxGQ==",
       "requires": {
         "klona": "^2.0.4",
         "loader-utils": "^2.0.0",
@@ -2679,9 +2679,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -2767,9 +2767,9 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "terser": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -2778,15 +2778,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
       }
     },
     "to-regex-range": {
@@ -2798,9 +2798,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -2829,9 +2829,9 @@
       }
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",


### PR DESCRIPTION
## Fixes
Fixes #138 
- #138 
  - [Prototype pollution in webpack loader-utils · CVE-2022-37601 · GitHub Advisory Database](https://github.com/advisories/GHSA-76p3-8jx3-jpfq)
  - [loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable · CVE-2022-37603 · GitHub Advisory Database](https://github.com/advisories/GHSA-3rfm-jhwj-7488)
  - [loader-utils is vulnerable to Regular Expression Denial of Service (ReDoS) · CVE-2022-37599 · GitHub Advisory Database](https://github.com/advisories/GHSA-hhq3-ff78-jv3g)

## Description
update npm packages

## Technical details
```shell
git checkout main
npm list --package-lock-only --depth 9 > npmlist.old
git checkout npm-upate
npm list --package-lock-only --depth 9 > npmlist.new
diff -u npmlist.old npmlist.new
```
```diff
--- npmlist.old	2022-11-21 07:24:00
+++ npmlist.new	2022-11-21 07:24:30
@@ -3,28 +3,28 @@
 ├── bulma@0.9.1
 ├─┬ css-loader@5.2.7
 │ ├─┬ icss-utils@5.1.0
-│ │ └── postcss@8.4.16 deduped
-│ ├─┬ loader-utils@2.0.2
+│ │ └── postcss@8.4.19 deduped
+│ ├─┬ loader-utils@2.0.4
 │ │ ├── big.js@5.2.2
 │ │ ├── emojis-list@3.0.0
 │ │ └── json5@2.2.1
 │ ├─┬ postcss-modules-extract-imports@3.0.0
-│ │ └── postcss@8.4.16 deduped
+│ │ └── postcss@8.4.19 deduped
 │ ├─┬ postcss-modules-local-by-default@4.0.0
 │ │ ├── icss-utils@5.1.0 deduped
-│ │ ├─┬ postcss-selector-parser@6.0.10
+│ │ ├─┬ postcss-selector-parser@6.0.11
 │ │ │ ├── cssesc@3.0.0
 │ │ │ └── util-deprecate@1.0.2
 │ │ ├── postcss-value-parser@4.2.0 deduped
-│ │ └── postcss@8.4.16 deduped
+│ │ └── postcss@8.4.19 deduped
 │ ├─┬ postcss-modules-scope@3.0.0
-│ │ ├── postcss-selector-parser@6.0.10 deduped
-│ │ └── postcss@8.4.16 deduped
+│ │ ├── postcss-selector-parser@6.0.11 deduped
+│ │ └── postcss@8.4.19 deduped
 │ ├─┬ postcss-modules-values@4.0.0
 │ │ ├── icss-utils@5.1.0 deduped
-│ │ └── postcss@8.4.16 deduped
+│ │ └── postcss@8.4.19 deduped
 │ ├── postcss-value-parser@4.2.0
-│ ├─┬ postcss@8.4.16
+│ ├─┬ postcss@8.4.19
 │ │ ├── nanoid@3.3.4
 │ │ ├── picocolors@1.0.0
 │ │ └── source-map-js@1.0.2 deduped
@@ -38,28 +38,28 @@
 │ │   ├── json-schema-traverse@0.4.1
 │ │   └─┬ uri-js@4.4.1
 │ │     └── punycode@2.1.1
-│ ├─┬ semver@7.3.7
+│ ├─┬ semver@7.3.8
 │ │ └─┬ lru-cache@6.0.0
 │ │   └── yallist@4.0.0
-│ └── webpack@5.74.0 deduped
+│ └── webpack@5.75.0 deduped
 ├─┬ mini-css-extract-plugin@1.6.2
-│ ├── loader-utils@2.0.2 deduped
+│ ├── loader-utils@2.0.4 deduped
 │ ├── schema-utils@3.1.1 deduped
 │ ├─┬ webpack-sources@1.4.3
 │ │ ├── source-list-map@2.0.1
 │ │ └── source-map@0.6.1
-│ └── webpack@5.74.0 deduped
-├─┬ sass-loader@10.3.1
+│ └── webpack@5.75.0 deduped
+├─┬ sass-loader@10.4.1
 │ ├── UNMET OPTIONAL DEPENDENCY fibers@>= 3.1.0
 │ ├── klona@2.0.5
-│ ├── loader-utils@2.0.2 deduped
+│ ├── loader-utils@2.0.4 deduped
 │ ├── neo-async@2.6.2
-│ ├── UNMET OPTIONAL DEPENDENCY node-sass@^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-│ ├── sass@1.54.4 deduped
+│ ├── UNMET OPTIONAL DEPENDENCY node-sass@^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+│ ├── sass@1.56.1 deduped
 │ ├── schema-utils@3.1.1 deduped
-│ ├── semver@7.3.7 deduped
-│ └── webpack@5.74.0 deduped
-├─┬ sass@1.54.4
+│ ├── semver@7.3.8 deduped
+│ └── webpack@5.75.0 deduped
+├─┬ sass@1.56.1
 │ ├─┬ chokidar@3.5.3
 │ │ ├─┬ anymatch@3.1.2
 │ │ │ ├── normalize-path@3.0.0 deduped
@@ -81,14 +81,14 @@
 │ ├── immutable@4.1.0
 │ └── source-map-js@1.0.2
 ├─┬ style-loader@2.0.0
-│ ├── loader-utils@2.0.2 deduped
+│ ├── loader-utils@2.0.4 deduped
 │ ├── schema-utils@3.1.1 deduped
-│ └── webpack@5.74.0 deduped
+│ └── webpack@5.75.0 deduped
 ├─┬ webpack-cli@4.10.0
 │ ├── @discoveryjs/json-ext@0.5.7
 │ ├─┬ @webpack-cli/configtest@1.2.0
 │ │ ├── webpack-cli@4.10.0 deduped
-│ │ └── webpack@5.74.0 deduped
+│ │ └── webpack@5.75.0 deduped
 │ ├─┬ @webpack-cli/info@1.5.0
 │ │ ├── envinfo@7.8.1
 │ │ └── webpack-cli@4.10.0 deduped
@@ -116,7 +116,7 @@
 │ ├── interpret@2.2.0
 │ ├─┬ rechoir@0.7.1
 │ │ └─┬ resolve@1.22.1
-│ │   ├─┬ is-core-module@2.10.0
+│ │   ├─┬ is-core-module@2.11.0
 │ │   │ └─┬ has@1.0.3
 │ │   │   └── function-bind@1.1.1
 │ │   ├── path-parse@1.0.7
@@ -129,10 +129,10 @@
 │ │ │ └─┬ shallow-clone@3.0.1
 │ │ │   └── kind-of@6.0.3 deduped
 │ │ └── wildcard@2.0.0
-│ └── webpack@5.74.0 deduped
-└─┬ webpack@5.74.0
+│ └── webpack@5.75.0 deduped
+└─┬ webpack@5.75.0
   ├─┬ @types/eslint-scope@3.7.4
-  │ ├─┬ @types/eslint@8.4.5
+  │ ├─┬ @types/eslint@8.4.10
   │ │ ├── @types/estree@0.0.51 deduped
   │ │ └── @types/json-schema@7.0.11 deduped
   │ └── @types/estree@0.0.51 deduped
@@ -177,14 +177,14 @@
   │ │ └── @xtuc/long@4.2.2 deduped
   │ └── @webassemblyjs/utf8@1.11.1
   ├─┬ acorn-import-assertions@1.8.0
-  │ └── acorn@8.8.0 deduped
-  ├── acorn@8.8.0
-  ├─┬ browserslist@4.21.3
-  │ ├── caniuse-lite@1.0.30001375
-  │ ├── electron-to-chromium@1.4.213
+  │ └── acorn@8.8.1 deduped
+  ├── acorn@8.8.1
+  ├─┬ browserslist@4.21.4
+  │ ├── caniuse-lite@1.0.30001434
+  │ ├── electron-to-chromium@1.4.284
   │ ├── node-releases@2.0.6
-  │ └─┬ update-browserslist-db@1.0.5
-  │   ├── browserslist@4.21.3 deduped
+  │ └─┬ update-browserslist-db@1.0.10
+  │   ├── browserslist@4.21.4 deduped
   │   ├── escalade@3.1.1
   │   └── picocolors@1.0.0 deduped
   ├── chrome-trace-event@1.0.3
@@ -206,12 +206,12 @@
   ├── neo-async@2.6.2 deduped
   ├── schema-utils@3.1.1 deduped
   ├── tapable@2.2.1
-  ├─┬ terser-webpack-plugin@5.3.3
-  │ ├─┬ @jridgewell/trace-mapping@0.3.14
+  ├─┬ terser-webpack-plugin@5.3.6
+  │ ├─┬ @jridgewell/trace-mapping@0.3.17
   │ │ ├── @jridgewell/resolve-uri@3.1.0
   │ │ └── @jridgewell/sourcemap-codec@1.4.14
   │ ├─┬ jest-worker@27.5.1
-  │ │ ├── @types/node@18.6.5
+  │ │ ├── @types/node@18.11.9
   │ │ ├── merge-stream@2.0.0
   │ │ └─┬ supports-color@8.1.1
   │ │   └── has-flag@4.0.0
@@ -219,19 +219,19 @@
   │ ├─┬ serialize-javascript@6.0.0
   │ │ └─┬ randombytes@2.1.0
   │ │   └── safe-buffer@5.2.1
-  │ ├─┬ terser@5.14.2
+  │ ├─┬ terser@5.15.1
   │ │ ├─┬ @jridgewell/source-map@0.3.2
   │ │ │ ├─┬ @jridgewell/gen-mapping@0.3.2
   │ │ │ │ ├── @jridgewell/set-array@1.1.2
   │ │ │ │ ├── @jridgewell/sourcemap-codec@1.4.14 deduped
-  │ │ │ │ └── @jridgewell/trace-mapping@0.3.14 deduped
-  │ │ │ └── @jridgewell/trace-mapping@0.3.14 deduped
-  │ │ ├── acorn@8.8.0 deduped
+  │ │ │ │ └── @jridgewell/trace-mapping@0.3.17 deduped
+  │ │ │ └── @jridgewell/trace-mapping@0.3.17 deduped
+  │ │ ├── acorn@8.8.1 deduped
   │ │ ├── commander@2.20.3
   │ │ └─┬ source-map-support@0.5.21
   │ │   ├── buffer-from@1.1.2
   │ │   └── source-map@0.6.1 deduped
-  │ └── webpack@5.74.0 deduped
+  │ └── webpack@5.75.0 deduped
   ├─┬ watchpack@2.4.0
   │ ├── glob-to-regexp@0.4.1 deduped
   │ └── graceful-fs@4.2.10 deduped
```

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
