### PR TITLE
Use compose-file-v2 and upgrade PostgreSQL to 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,9 +54,9 @@ jobs:
     services:
       postgres:
         # https://hub.docker.com/_/postgres
-        # https://devcenter.heroku.com/articles/heroku-postgresql#version-support
+        # https://devcenter.heroku.com/articles/heroku-postgres-version-support
         # Match version to Heroku app. Keep in sync with docker-compose.yml
-        image: postgres:14-alpine
+        image: postgres:15-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     # https://devcenter.heroku.com/articles/getting-started-with-python
     # Match version to Heroku app
     # Keep in sync with Dockerfile and Pipfile
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -41,7 +41,7 @@ jobs:
         pipenv run flake8 . --output-file test-reports/flake8
 
     - name: Upload flake test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: flake8-report
           path: test-reports/flake8
@@ -72,13 +72,13 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
     # https://devcenter.heroku.com/articles/getting-started-with-python
     # Match version to Heroku app
     # Keep in sync with Dockerfile and Pipfile
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,9 @@
-# https://docs.docker.com/compose/compose-file/compose-file-v3/
-version: "3"
+# Also see:
+#   Dockerfile
+#
+# https://docs.docker.com/compose/compose-file/compose-file-v2/
+
+version: "2.4"
 
 services:
 
@@ -30,9 +34,9 @@ services:
       - POSTGRES_USER=${DJANGO_DATABASE_USER}
       - POSTGRES_PASSWORD=${DJANGO_DATABASE_PASSWORD:-postgres}
     # https://hub.docker.com/_/postgres
-    # https://devcenter.heroku.com/articles/heroku-postgresql#version-support
+    # https://devcenter.heroku.com/articles/heroku-postgres-version-support
     # Match version to Heroku app. Keep in sync with .github/workflows/main.yml
-    image: postgres:14-alpine
+    image: postgres:15-alpine
     restart: always
     volumes:
       - ./tmp/pgdata/:/var/lib/postgresql/data


### PR DESCRIPTION
## Fixes
Fixes #166, fixes creativecommons/tech-support#1133 (private repo)
- #166 

## Description
- use compose-file-v2 since we are not using swarm mode
- upgrade PostgreSQL to 15
- update GitHub Actions uses: versions
  - ~~`actions/checkout@v3`~~ ➡️ `actions/checkout@v4`
  - ~~`actions/setup-python@v4`~~ ➡️ `actions/setup-python@v5`
  - ~~`actions/upload-artifact@v3`~~ ➡️ `actions/upload-artifact@v4`

## Technical details
- [Compose file version 3 reference](https://docs.docker.com/compose/compose-file/compose-file-v3/):
  > ⚠️ **Looking for options to set resources on non swarm mode containers?**
  >
  > The options described here are specific to the deploy key and swarm mode. If you want to set resource constraints on non swarm deployments, use [Compose file format version 2 CPU, memory, and other resource options](https://docs.docker.com/compose/compose-file/compose-file-v2/#cpu-and-other-resources). If you have further questions, refer to the discussion on the GitHub issue [docker/compose/4513](https://github.com/docker/compose/issues/4513).
  - https://github.com/docker/compose/issues/4513#issuecomment-281478365
    >> Are we just expected to stay on v2.1 if we want to use docker-compose and not swarm mode?
    >
    > Yes.
  - https://github.com/docker/compose/issues/4513#issuecomment-289620945
    > Yes, we will continue to maintain and add to the v2 format for the foreseeable future. The hope is that in time, the v3 format + docker stack will be an equivalent or even better solution for most use-cases and that everyone will want to use it, but we know we have a long way to go until we get there.
-  [Compose file version 2 reference](https://docs.docker.com/compose/compose-file/compose-file-v2/)
- Local PostgreSQL upgrade process
  1. $ `docker compose up`
  2. $ `docker compose exec -it db pg_dumpall > upgrade_backup.sql`
  3. $ `docker compose down`
  4. Modify `docker-compose.yml`
  5. $ `mv tmp tmp.$(date '+%Y%m%d')`
  6. $ `docker compose up`
  7. $ `docker compose exec -T db psql -U postgres < upgrade_backup.sql`
  8. $ `docker compose down`

## Tests
```
Ran 13 tests in 1.809s

OK
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
