### PR TITLE
[Fix] Missing Form Method on <form> Element in _search.html 

### DIFF
--- a/legal_db/templates/legal_db/partials/_search.html
+++ b/legal_db/templates/legal_db/partials/_search.html
@@ -2,16 +2,18 @@
 
 <section class="columns is-gapless is-vcentered margin-top-big margin-bottom-small">
   <div class="column is-8">
-    <form role="search" method="get" class="field has-addons">
-      <div class="control has-icons-left search-input">
-        <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
-        {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
-        <span class="icon is-left"><i class="icon search"></i></span>
-      </div>
-      <div class="control is-4">
-        <button type="submit" class="button small">Search</button>
-      </div>
-    </form>
+    <div class="content field has-addons">
+      <form role="search" method="get">
+        <div class="control has-icons-left search-input">
+          <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
+         {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
+          <span class="icon is-left"><i class="icon search"></i></span>
+        </div>
+        <div class="control is-4">
+         <button type="submit" class="button small">Search</button>
+        </div>
+      </form>
+    </div>
     {{ form.keywords.errors }}
   </div>
   <div class="column">

--- a/legal_db/templates/legal_db/partials/_search.html
+++ b/legal_db/templates/legal_db/partials/_search.html
@@ -1,23 +1,32 @@
 {% load widget_tweaks %}
 
-<section class="columns is-gapless is-vcentered margin-top-big margin-bottom-small">
-  <div class="column is-8">
-    <div role="search" method="get" class="field has-addons">
-      <div class="control has-icons-left search-input">
-        <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
-        {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
-        <span class="icon is-left"><i class="icon search"></i></span>
-      </div>
-      <div class="control is-4">
-        <button type="submit" class="button small">Search</button>
-      </div>
-    </div>
-    {{ form.keywords.errors }}
-  </div>
-  <div class="column">
-    <strong id="tags-filter" class="tags-filter margin-left-normal">
-      <span id="tags-hide">Hide topic filters <i class="icon chevron-up"></i></span>
-      <span id="tags-show" class="is-hidden">Show topic filters <i class="icon chevron-down"></i></span>
-    </strong>
-  </div>
+<section
+	class="columns is-gapless is-vcentered margin-top-big margin-bottom-small"
+>
+	<div class="column is-8">
+		<form role="search" method="get" class="field has-addons">
+			<div class="control has-icons-left search-input">
+				<label for="{{ form.keywords.id_for_label }}" class="is-sr-only"
+					>Search:
+				</label>
+				{% render_field form.keywords|add_class:"input" placeholder="Search
+				for..." %}
+				<span class="icon is-left"><i class="icon search"></i></span>
+			</div>
+			<div class="control is-4">
+				<button type="submit" class="button small">Search</button>
+			</div>
+		</form>
+		{{ form.keywords.errors }}
+	</div>
+	<div class="column">
+		<strong id="tags-filter" class="tags-filter margin-left-normal">
+			<span id="tags-hide"
+				>Hide topic filters <i class="icon chevron-up"></i
+			></span>
+			<span id="tags-show" class="is-hidden"
+				>Show topic filters <i class="icon chevron-down"></i
+			></span>
+		</strong>
+	</div>
 </section>

--- a/legal_db/templates/legal_db/partials/_search.html
+++ b/legal_db/templates/legal_db/partials/_search.html
@@ -1,32 +1,23 @@
 {% load widget_tweaks %}
 
-<section
-	class="columns is-gapless is-vcentered margin-top-big margin-bottom-small"
->
-	<div class="column is-8">
-		<form role="search" method="get" class="field has-addons">
-			<div class="control has-icons-left search-input">
-				<label for="{{ form.keywords.id_for_label }}" class="is-sr-only"
-					>Search:
-				</label>
-				{% render_field form.keywords|add_class:"input" placeholder="Search
-				for..." %}
-				<span class="icon is-left"><i class="icon search"></i></span>
-			</div>
-			<div class="control is-4">
-				<button type="submit" class="button small">Search</button>
-			</div>
-		</form>
-		{{ form.keywords.errors }}
-	</div>
-	<div class="column">
-		<strong id="tags-filter" class="tags-filter margin-left-normal">
-			<span id="tags-hide"
-				>Hide topic filters <i class="icon chevron-up"></i
-			></span>
-			<span id="tags-show" class="is-hidden"
-				>Show topic filters <i class="icon chevron-down"></i
-			></span>
-		</strong>
-	</div>
+<section class="columns is-gapless is-vcentered margin-top-big margin-bottom-small">
+  <div class="column is-8">
+    <form role="search" method="get" class="field has-addons">
+      <div class="control has-icons-left search-input">
+        <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
+        {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
+        <span class="icon is-left"><i class="icon search"></i></span>
+      </div>
+      <div class="control is-4">
+        <button type="submit" class="button small">Search</button>
+      </div>
+    </form>
+    {{ form.keywords.errors }}
+  </div>
+  <div class="column">
+    <strong id="tags-filter" class="tags-filter margin-left-normal">
+      <span id="tags-hide">Hide topic filters <i class="icon chevron-up"></i></span>
+      <span id="tags-show" class="is-hidden">Show topic filters <i class="icon chevron-down"></i></span>
+    </strong>
+  </div>
 </section>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #211 by @wendy640

## Description
<!-- Concisely describe what the pull request does. -->
This pull request fixes an issue where the method attribute was incorrectly placed on a 'div' element instead of the 'form' element in the search functionality. This misplacement could lead to unexpected behavior during form submission. The fix ensures proper HTML standards are followed by relocating the `method="get"` attribute to the 'form' element.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
1. Moved the `method="get"` attribute from `<div>` to `<form>` within the `_search.html` file.
2. Ensured that the form is now correctly structured for proper submission behavior.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
