### PR TITLE
Fix: Input the missing "media=all" attribute in the <link> tag 

### DIFF
--- a/legal_db/templates/legal_db/base.html
+++ b/legal_db/templates/legal_db/base.html
@@ -9,7 +9,7 @@
     <meta name="description" content="This database contains case law and legal scholarship about CC licenses and the issues that relate to their enforceability and interpretation."/>
     <title>CC Legal Database</title>
     <link rel="icon" href="{% static 'favicon.ico' %}"/>
-    <link rel="stylesheet" href="{% static 'webpack_files/css/index.css' %}" type="text/css">
+    <link rel="stylesheet" href="{% static 'webpack_files/css/index.css' %}" type="text/css" media="all">
   </head>
   <body>
     {% include 'legal_db/partials/_header.html' %}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #220 by @SisiVero

## Description
The <link> tag for the CSS file was missing the media attribute, which is required for proper HTML semantics. In the vocabulary docs, link tag for stylesheets must have the media="all". The media='all' was added to the link tag.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests

1. Clone the repo and go to base.html in scholarship folder
2. Observe that the `<link>` tag for the CSS file now includes a media attribute:
   https://github.com/babyteega/legaldb/blob/4326db76c9528534588750ea9abd8eadaeae97c9/legal_db/templates/legal_db/base.html#L12
   - Previous <link>tag
     https://github.com/creativecommons/legaldb/blob/83e0303b56e2a97b6fefd627bb049b9dd380b028/legal_db/templates/legal_db/base.html#L12
3. See correction.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
