### PR TITLE
[Fix] Title Heading Misalignment on Larger Screens

### DIFF
--- a/legal_db/templates/legal_db/index.html
+++ b/legal_db/templates/legal_db/index.html
@@ -11,7 +11,7 @@
     <div class="container">
 			<div class="columns is-centered is-paddingless">
             <div class="column is-half has-text-centered">
-            <h2 class="title is-3 ent">Explore by content</h2>
+            <h2 class="title is-3">Explore by content</h2>
             </div>
         </div>
       <div class="columns is-multiline is-vcentered is-paddingless">

--- a/legal_db/templates/legal_db/index.html
+++ b/legal_db/templates/legal_db/index.html
@@ -9,9 +9,13 @@
   </section>
   <section class="explore">
     <div class="container">
+			<div class="columns is-centered is-paddingless">
+            <div class="column is-half has-text-centered">
+            <h2 class="title is-3 ent">Explore by content</h2>
+            </div>
+        </div>
       <div class="columns is-multiline is-vcentered is-paddingless">
         <div class="column is-half">
-          <h2 class="title is-3">Explore by content</h2>
           <div class="padding-top-large">
             <h3 class="subtitle is-4 padding-bottom-big">Cases</h3>
             {% for tag in cases_tags %}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #206 by @wendy640

## Description
<!-- Concisely describe what the pull request does. -->
This pull request resolves the misalignment issue of the "Explore by content" heading on larger screens. The heading was not centrally aligned and did not appear directly above the associated content, causing an inconsistent visual layout. The fix adjusts the HTML to ensure the heading is centered and aligned properly, creating a more consistent layout across all screen sizes.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
The alignment issue was resolved by restructuring the HTML to use centered columns
`<div class="columns is-centered is-paddingless">
            <div class="column is-half has-text-centered">
            <h2 class="title is-3">Explore by content</h2>
            </div>
        </div>`
        
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

- Open the affected page on a larger screen (e.g., 1920x1080 resolution).

- Verify that the "Explore by content" heading is now centrally aligned and positioned directly above the related content (case tags and scholarship tags).

- Confirm that the padding below the heading creates the intended visual separation, improving readability.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
Before
![Screen Shot 2024-10-09 at 7 37 39 PM](https://github.com/user-attachments/assets/289433fd-27c7-4a92-986c-83a0ce7df43f)


After
![Screen Shot 2024-10-15 at 2 16 54 PM](https://github.com/user-attachments/assets/295b6987-7266-4095-912e-5c6274b308f8)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
        visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
