### PR TITLE
Restore filter functionality

### DIFF
--- a/legal_db/templates/legal_db/partials/_search.html
+++ b/legal_db/templates/legal_db/partials/_search.html
@@ -2,17 +2,15 @@
 
 <section class="columns is-gapless is-vcentered margin-top-big margin-bottom-small">
   <div class="column is-8">
-    <div class="content field has-addons">
-      <form role="search" method="get">
-        <div class="control has-icons-left search-input">
-          <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
-         {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
-          <span class="icon is-left"><i class="icon search"></i></span>
-        </div>
-        <div class="control is-4">
-         <button type="submit" class="button small">Search</button>
-        </div>
-      </form>
+    <div class="field has-addons">
+      <div class="control has-icons-left search-input">
+        <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
+        {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
+        <span class="icon is-left"><i class="icon search"></i></span>
+      </div>
+      <div class="control is-4">
+        <button type="submit" class="button small">Search</button>
+      </div>
     </div>
     {{ form.keywords.errors }}
   </div>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #211
- Fixes #223 

## Description
Restore filter functionality by restoring previous commit content ([`[9087488](https://github.com/creativecommons/legaldb/commit/9087488b3e9a4cecfbabc4daeb581403f178198f)`](https://github.com/creativecommons/legaldb/blob/9087488b3e9a4cecfbabc4daeb581403f178198f/legal_db/templates/legal_db/partials/_search.html)) with `role="search" method="get"` removed. This reverts #223 and instead:
```diff
--- legal_db/templates/legal_db/partials/_search.html.9087488	2024-10-21 10:22:30
+++ legal_db/templates/legal_db/partials/_search.html	2024-10-21 10:23:29
@@ -2,7 +2,7 @@
 
 <section class="columns is-gapless is-vcentered margin-top-big margin-bottom-small">
   <div class="column is-8">
-    <div role="search" method="get" class="field has-addons">
+    <div class="field has-addons">
       <div class="control has-icons-left search-input">
         <label for="{{ form.keywords.id_for_label }}" class="is-sr-only">Search: </label>
         {% render_field form.keywords|add_class:"input" placeholder="Search for..." %}
```


## Technical details
When testing a newer pull request (PR), I realized that the filters weren't working. Upon further investigation:

I thought that #223 fixed, this, but I did not realize the larger picture.
- #223 
  - replaced `<div` with `<form`
  - What I didn't realize is that the `_search.html` template fragment is called from:
     - https://github.com/creativecommons/legaldb/blob/475900b7567465a5489d8b6bf96b575443260a5d/legal_db/templates/legal_db/case/index.html#L26-L27
       - (note `<form` opening tag)
     - https://github.com/creativecommons/legaldb/blob/475900b7567465a5489d8b6bf96b575443260a5d/legal_db/templates/legal_db/scholarship/index.html#L26-L27
       - (note `<form` opening tag)
  - the PR added a second `<form>` tag with the existing `<form>`

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
