### PR TITLE
Fix : CSS Style Conflicts in explore-panel 

### DIFF
--- a/legal_db/static/webpack_files/css/index.css
+++ b/legal_db/static/webpack_files/css/index.css
@@ -1,2 +1,10101 @@
 @import url(https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css);
-/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */html,body,p,ol,ul,li,dl,dt,dd,blockquote,figure,fieldset,legend,textarea,pre,iframe,hr,h1,h2,h3,h4,h5,h6{margin:0;padding:0}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal}ul{list-style:none}button,input,select,textarea{margin:0}html{box-sizing:border-box}*,*::before,*::after{box-sizing:inherit}img,video{height:auto;max-width:100%}iframe{border:0}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}td:not([align]),th:not([align]){text-align:inherit}.has-background-tomato{background-color:#e23600}.has-text-tomato,.has-color-tomato{color:#e23600}.has-background-gold{background-color:#efbe00}.has-text-gold,.has-color-gold{color:#efbe00}.has-background-forest-green{background-color:#008300}.has-text-forest-green,.card.entry-post.project-index .card-content .site-link,.has-color-forest-green,.card.entry-post.project-index .card-content .site-link .icon{color:#008300}.has-background-dark-turquoise{background-color:#05b5da}.has-text-dark-turquoise,.has-color-dark-turquoise{color:#05b5da}.has-background-dark-slate-blue{background-color:#3c5c99}.has-text-dark-slate-blue,.has-color-dark-slate-blue{color:#3c5c99}.has-background-brighter-dark-slate-blue{background-color:#1066e7}.has-text-brighter-dark-slate-blue,.has-color-brighter-dark-slate-blue{color:#1066e7}.has-background-dark-slate-gray{background-color:#333}.has-text-dark-slate-gray,.has-color-dark-slate-gray,.table-of-progress .step .link,.card.blog-entry .blog-content .excerpt{color:#333}.padding-smaller{padding:.25rem !important}.padding-small{padding:.5rem !important}.padding-normal,.tabs-content.is-boxed{padding:1rem !important}.padding-big,.table-of-contents{padding:1.5rem !important}.padding-bigger{padding:2rem !important}.padding-large{padding:2.5rem !important}.padding-larger{padding:3rem !important}.padding-xl{padding:4rem !important}.padding-xxl{padding:6rem !important}.margin-smaller{margin:.25rem !important}.margin-small{margin:.5rem !important}.margin-normal{margin:1rem !important}.margin-big{margin:1.5rem !important}.margin-bigger{margin:2rem !important}.margin-large{margin:2.5rem !important}.margin-larger{margin:3rem !important}.margin-xl{margin:4rem !important}.margin-xxl{margin:6rem !important}.body-bigger{line-height:1.6;font-size:1.43rem}.body-big{line-height:1.6;font-size:1.12rem}.body-normal,.table-of-progress .step .link,.table-of-contents,.sidebar-menu,.table,.card.blog-entry .blog-content .excerpt,.card.blog-entry .blog-content .blog-author{line-height:1.6;font-size:1rem}.body-list{line-height:1.6;font-size:1rem}.caption,.image .image-title{font-size:.8rem}.value{font-family:"Roboto Condensed",sans-serif;font-size:4.37rem;font-weight:bold;line-height:1.3;letter-spacing:.02em}.monospace{font-family:"JetBrains Mono",monospace;font-size:.875em}h1,h2,h3,h4,h5,h6,.title{color:#333;font-family:"Roboto Condensed",sans-serif;font-weight:bold;text-transform:uppercase;line-height:1.3;letter-spacing:.02rem}.b-header,.table-of-progress .step-header,.subtitle{color:#333;font-family:"Source Sans Pro",sans-serif;font-weight:bold;text-transform:none;line-height:1.3;letter-spacing:.02rem}h1,.title.is-1,.subtitle.is-1{font-size:3.56rem}h2,.title.is-2,.subtitle.is-2{font-size:2.25rem}h3,.title.is-3,.subtitle.is-3{font-size:1.75rem}h4,.title.is-4,.subtitle.is-4{font-size:1.43rem}h5,.title.is-5,.subtitle.is-5{font-size:1.25rem}h6,.title.is-6,.subtitle.is-6{font-size:1.15rem}body{font-family:"Source Sans Pro",sans-serif;font-size:1rem}a:hover{text-decoration:underline}@keyframes spinAround{from{transform:rotate(0deg)}to{transform:rotate(359deg)}}.pagination-previous,.pagination-next,.pagination-link,.pagination-ellipsis,.breadcrumb,.tabs,.file,.button,.is-unselectable{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.navbar-link:not(.is-arrowless)::after,.select:not(.is-multiple):not(.is-loading)::after{border:3px solid rgba(0,0,0,0);border-radius:2px;border-right:0;border-top:0;content:" ";display:block;height:.625em;margin-top:-0.4375em;pointer-events:none;position:absolute;top:50%;transform:rotate(-45deg);transform-origin:center;width:.625em}.content:not(:last-child),.level:not(:last-child),.pagination:not(:last-child),.breadcrumb:not(:last-child),.tabs:not(:last-child),.table-container:not(:last-child),.table:not(:last-child){margin-bottom:1.5rem}.control.is-loading::after,.select.is-loading::after,.button.is-loading::after{animation:spinAround 500ms infinite linear;border:2px solid #f5f5f5;border-radius:290486px;border-right-color:rgba(0,0,0,0);border-top-color:rgba(0,0,0,0);content:"";display:block;height:1em;position:relative;width:1em}.image.is-square img,.image.is-square .has-ratio,.image.is-1by1 img,.image.is-1by1 .has-ratio,.image.is-5by4 img,.image.is-5by4 .has-ratio,.image.is-4by3 img,.image.is-4by3 .has-ratio,.image.is-3by2 img,.image.is-3by2 .has-ratio,.image.is-5by3 img,.image.is-5by3 .has-ratio,.image.is-16by9 img,.image.is-16by9 .has-ratio,.image.is-2by1 img,.image.is-2by1 .has-ratio,.image.is-3by1 img,.image.is-3by1 .has-ratio,.image.is-4by5 img,.image.is-4by5 .has-ratio,.image.is-3by4 img,.image.is-3by4 .has-ratio,.image.is-2by3 img,.image.is-2by3 .has-ratio,.image.is-3by5 img,.image.is-3by5 .has-ratio,.image.is-9by16 img,.image.is-9by16 .has-ratio,.image.is-1by2 img,.image.is-1by2 .has-ratio,.image.is-1by3 img,.image.is-1by3 .has-ratio,.is-overlay{bottom:0;left:0;position:absolute;right:0;top:0}.pagination-previous,.pagination-next,.pagination-link,.pagination-ellipsis,.file-cta,.file-name,.select select,.textarea,.input,.button{-moz-appearance:none;-webkit-appearance:none;align-items:center;border:1px solid rgba(0,0,0,0);border-radius:4px;box-shadow:none;display:inline-flex;font-size:1rem;height:2.5em;justify-content:flex-start;line-height:1.5;padding-bottom:calc(.5em - 1px);padding-left:calc(.75em - 1px);padding-right:calc(.75em - 1px);padding-top:calc(.5em - 1px);position:relative;vertical-align:top}.pagination-previous:focus,.pagination-next:focus,.pagination-link:focus,.pagination-ellipsis:focus,.file-cta:focus,.file-name:focus,.select select:focus,.textarea:focus,.input:focus,.button:focus,.is-focused.pagination-previous,.is-focused.pagination-next,.is-focused.pagination-link,.is-focused.pagination-ellipsis,.is-focused.file-cta,.is-focused.file-name,.select select.is-focused,.is-focused.textarea,.is-focused.input,.is-focused.button,.pagination-previous:active,.pagination-next:active,.pagination-link:active,.pagination-ellipsis:active,.file-cta:active,.file-name:active,.select select:active,.textarea:active,.input:active,.button:active,.is-active.pagination-previous,.is-active.pagination-next,.is-active.pagination-link,.is-active.pagination-ellipsis,.table-of-progress .step :hover .number.pagination-previous,.table-of-progress .step :hover .number.pagination-next,.table-of-progress .step :hover .number.pagination-link,.table-of-progress .step :hover .number.pagination-ellipsis,.table-of-progress .step :hover .is-active.pagination-previous,.table-of-progress .step :hover .is-active.pagination-next,.table-of-progress .step :hover .is-active.pagination-link,.table-of-progress .step :hover .is-active.pagination-ellipsis,.is-active.file-cta,.table-of-progress .step :hover .file-cta.number,.table-of-progress .step :hover .file-cta.is-active,.is-active.file-name,.table-of-progress .step :hover .file-name.number,.table-of-progress .step :hover .file-name.is-active,.select select.is-active,.select .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select select.number,.select .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select select.is-active,.is-active.textarea,.table-of-progress .step :hover .textarea.number,.table-of-progress .step :hover .textarea.is-active,.is-active.input,.table-of-progress .step :hover .input.number,.table-of-progress .step :hover .input.is-active,.is-active.button,.table-of-progress .step :hover .button.number,.table-of-progress .step :hover .button.is-active{outline:none}[disabled].pagination-previous,[disabled].pagination-next,[disabled].pagination-link,[disabled].pagination-ellipsis,[disabled].file-cta,[disabled].file-name,.select select[disabled],[disabled].textarea,[disabled].input,[disabled].button,fieldset[disabled] .pagination-previous,fieldset[disabled] .pagination-next,fieldset[disabled] .pagination-link,fieldset[disabled] .pagination-ellipsis,fieldset[disabled] .file-cta,fieldset[disabled] .file-name,fieldset[disabled] .select select,.select fieldset[disabled] select,fieldset[disabled] .textarea,fieldset[disabled] .input,fieldset[disabled] .button{cursor:not-allowed}.has-text-white,.image .bookmark-icon,.image .image-title{color:#fff !important}a.has-text-white:hover,.image a.bookmark-icon:hover,.image a.image-title:hover,a.has-text-white:focus,.image a.bookmark-icon:focus,.image a.image-title:focus{color:#e6e6e6 !important}.has-background-white{background-color:#fff !important}.has-text-black,.image .image-icons{color:#000 !important}a.has-text-black:hover,.image a.image-icons:hover,a.has-text-black:focus,.image a.image-icons:focus{color:#000 !important}.has-background-black,.image .bookmark-icon,.image .image-title{background-color:#000 !important}.has-text-light{color:#f5f5f5 !important}a.has-text-light:hover,a.has-text-light:focus{color:#dbdbdb !important}.has-background-light{background-color:#f5f5f5 !important}.has-text-dark{color:#363636 !important}a.has-text-dark:hover,a.has-text-dark:focus{color:#1c1c1c !important}.has-background-dark{background-color:#363636 !important}.has-text-primary{color:#e23600 !important}a.has-text-primary:hover,a.has-text-primary:focus{color:#af2a00 !important}.has-background-primary{background-color:#e23600 !important}.has-text-primary-light{color:#ffefeb !important}a.has-text-primary-light:hover,a.has-text-primary-light:focus{color:#ffc9b8 !important}.has-background-primary-light{background-color:#ffefeb !important}.has-text-primary-dark{color:#eb3800 !important}a.has-text-primary-dark:hover,a.has-text-primary-dark:focus{color:#ff541f !important}.has-background-primary-dark{background-color:#eb3800 !important}.has-text-link{color:#e23600 !important}a.has-text-link:hover,a.has-text-link:focus{color:#af2a00 !important}.has-background-link{background-color:#e23600 !important}.has-text-link-light{color:#ffefeb !important}a.has-text-link-light:hover,a.has-text-link-light:focus{color:#ffc9b8 !important}.has-background-link-light{background-color:#ffefeb !important}.has-text-link-dark{color:#eb3800 !important}a.has-text-link-dark:hover,a.has-text-link-dark:focus{color:#ff541f !important}.has-background-link-dark{background-color:#eb3800 !important}.has-text-info{color:#1950b8 !important}a.has-text-info:hover,a.has-text-info:focus{color:#133c8b !important}.has-background-info{background-color:#1950b8 !important}.has-text-info-light{color:#d1dcf1 !important}a.has-text-info-light:hover,a.has-text-info-light:focus{color:#aabee5 !important}.has-background-info-light{background-color:#d1dcf1 !important}.has-text-info-dark{color:#1950b8 !important}a.has-text-info-dark:hover,a.has-text-info-dark:focus{color:#2365e1 !important}.has-background-info-dark{background-color:#1950b8 !important}.has-text-success{color:#008300 !important}a.has-text-success:hover,a.has-text-success:focus{color:#005000 !important}.has-background-success{background-color:#008300 !important}.has-text-success-light{color:#e0f2bf !important}a.has-text-success-light:hover,a.has-text-success-light:focus{color:#cbe995 !important}.has-background-success-light{background-color:#e0f2bf !important}.has-text-success-dark{color:#008300 !important}a.has-text-success-dark:hover,a.has-text-success-dark:focus{color:#00b600 !important}.has-background-success-dark{background-color:#008300 !important}.has-text-warning{color:#f2ab20 !important}a.has-text-warning:hover,a.has-text-warning:focus{color:#d3900c !important}.has-background-warning{background-color:#f2ab20 !important}.has-text-warning-light{color:#faecbc !important}a.has-text-warning-light:hover,a.has-text-warning-light:focus{color:#f6df8d !important}.has-background-warning-light{background-color:#faecbc !important}.has-text-warning-dark{color:#f2ab20 !important}a.has-text-warning-dark:hover,a.has-text-warning-dark:focus{color:#f5bd50 !important}.has-background-warning-dark{background-color:#f2ab20 !important}.has-text-danger{color:#c83b1e !important}a.has-text-danger:hover,a.has-text-danger:focus{color:#9c2e17 !important}.has-background-danger{background-color:#c83b1e !important}.has-text-danger-light{color:#ffc9c9 !important}a.has-text-danger-light:hover,a.has-text-danger-light:focus{color:#ff9696 !important}.has-background-danger-light{background-color:#ffc9c9 !important}.has-text-danger-dark{color:#c83b1e !important}a.has-text-danger-dark:hover,a.has-text-danger-dark:focus{color:#e15538 !important}.has-background-danger-dark{background-color:#c83b1e !important}.has-text-black-bis{color:#121212 !important}.has-background-black-bis{background-color:#121212 !important}.has-text-black-ter{color:#242424 !important}.has-background-black-ter{background-color:#242424 !important}.has-text-grey-darker{color:#363636 !important}.has-background-grey-darker{background-color:#363636 !important}.has-text-grey-dark{color:#767676 !important}.has-background-grey-dark{background-color:#767676 !important}.has-text-grey,.table-of-contents .icon,.sidebar-menu .icon{color:#b0b0b0 !important}.has-background-grey{background-color:#b0b0b0 !important}.has-text-grey-light{color:#d8d8d8 !important}.has-background-grey-light{background-color:#d8d8d8 !important}.has-text-grey-lighter{color:#f5f5f5 !important}.has-background-grey-lighter{background-color:#f5f5f5 !important}.has-text-white-ter{color:#f5f5f5 !important}.has-background-white-ter{background-color:#f5f5f5 !important}.has-text-white-bis{color:#fafafa !important}.has-background-white-bis{background-color:#fafafa !important}.is-flex-direction-row{flex-direction:row !important}.is-flex-direction-row-reverse{flex-direction:row-reverse !important}.is-flex-direction-column{flex-direction:column !important}.is-flex-direction-column-reverse{flex-direction:column-reverse !important}.is-flex-wrap-nowrap{flex-wrap:nowrap !important}.is-flex-wrap-wrap{flex-wrap:wrap !important}.is-flex-wrap-wrap-reverse{flex-wrap:wrap-reverse !important}.is-justify-content-flex-start{justify-content:flex-start !important}.is-justify-content-flex-end{justify-content:flex-end !important}.is-justify-content-center{justify-content:center !important}.is-justify-content-space-between{justify-content:space-between !important}.is-justify-content-space-around{justify-content:space-around !important}.is-justify-content-space-evenly{justify-content:space-evenly !important}.is-justify-content-start{justify-content:start !important}.is-justify-content-end{justify-content:end !important}.is-justify-content-left{justify-content:left !important}.is-justify-content-right{justify-content:right !important}.is-align-content-flex-start{align-content:flex-start !important}.is-align-content-flex-end{align-content:flex-end !important}.is-align-content-center{align-content:center !important}.is-align-content-space-between{align-content:space-between !important}.is-align-content-space-around{align-content:space-around !important}.is-align-content-space-evenly{align-content:space-evenly !important}.is-align-content-stretch{align-content:stretch !important}.is-align-content-start{align-content:start !important}.is-align-content-end{align-content:end !important}.is-align-content-baseline{align-content:baseline !important}.is-align-items-stretch{align-items:stretch !important}.is-align-items-flex-start{align-items:flex-start !important}.is-align-items-flex-end{align-items:flex-end !important}.is-align-items-center{align-items:center !important}.is-align-items-baseline{align-items:baseline !important}.is-align-items-start{align-items:start !important}.is-align-items-end{align-items:end !important}.is-align-items-self-start{align-items:self-start !important}.is-align-items-self-end{align-items:self-end !important}.is-align-self-auto{align-self:auto !important}.is-align-self-flex-start{align-self:flex-start !important}.is-align-self-flex-end{align-self:flex-end !important}.is-align-self-center{align-self:center !important}.is-align-self-baseline{align-self:baseline !important}.is-align-self-stretch{align-self:stretch !important}.is-flex-grow-0{flex-grow:0 !important}.is-flex-grow-1{flex-grow:1 !important}.is-flex-grow-2{flex-grow:2 !important}.is-flex-grow-3{flex-grow:3 !important}.is-flex-grow-4{flex-grow:4 !important}.is-flex-grow-5{flex-grow:5 !important}.is-flex-shrink-0{flex-shrink:0 !important}.is-flex-shrink-1{flex-shrink:1 !important}.is-flex-shrink-2{flex-shrink:2 !important}.is-flex-shrink-3{flex-shrink:3 !important}.is-flex-shrink-4{flex-shrink:4 !important}.is-flex-shrink-5{flex-shrink:5 !important}.is-clearfix::after{clear:both;content:" ";display:table}.is-pulled-left{float:left !important}.is-pulled-right{float:right !important}.is-radiusless{border-radius:0 !important}.is-shadowless{box-shadow:none !important}.is-clickable{cursor:pointer !important}.is-clipped{overflow:hidden !important}.is-relative{position:relative !important}.is-marginless{margin:0 !important}.is-paddingless,.image.is-compact .image-icons,.sidebar-menu .menu-list .link,.card.entry-post.project-index .card-content .content,.button.is-text{padding:0 !important}.margin--0{margin:0 !important}.margin-top-0{margin-top:0 !important}.margin-right-0{margin-right:0 !important}.margin-bottom-0{margin-bottom:0 !important}.margin-left-0{margin-left:0 !important}.margin-horizontal-0{margin-left:0 !important;margin-right:0 !important}.margin-vertical-0{margin-top:0 !important;margin-bottom:0 !important}.margin--smaller{margin:.25rem !important}.margin-top-smaller{margin-top:.25rem !important}.margin-right-smaller{margin-right:.25rem !important}.margin-bottom-smaller{margin-bottom:.25rem !important}.margin-left-smaller{margin-left:.25rem !important}.margin-horizontal-smaller{margin-left:.25rem !important;margin-right:.25rem !important}.margin-vertical-smaller{margin-top:.25rem !important;margin-bottom:.25rem !important}.margin--small{margin:.5rem !important}.margin-top-small,.card.blog-entry .blog-content .blog-author,.card.entry-post.project-index .card-content .site-link{margin-top:.5rem !important}.margin-right-small,.card.entry-post.project-index .card-content .labels .button{margin-right:.5rem !important}.margin-bottom-small,.sidebar-menu .divider,.card.entry-post.project-index .card-content .external-links .button{margin-bottom:.5rem !important}.margin-left-small{margin-left:.5rem !important}.margin-horizontal-small{margin-left:.5rem !important;margin-right:.5rem !important}.margin-vertical-small{margin-top:.5rem !important;margin-bottom:.5rem !important}.margin--normal{margin:1rem !important}.margin-top-normal,.table-of-contents,.sidebar-menu .divider,.card.blog-entry .blog-content .excerpt,.card.entry-post.project-index .card-content .labels{margin-top:1rem !important}.margin-right-normal{margin-right:1rem !important}.margin-bottom-normal,.card.entry-post.project-index .card-content .labels .button,.card.entry-post.project-index .card-content .labels{margin-bottom:1rem !important}.margin-left-normal,.table-of-progress .step .name{margin-left:1rem !important}.margin-horizontal-normal{margin-left:1rem !important;margin-right:1rem !important}.margin-vertical-normal{margin-top:1rem !important;margin-bottom:1rem !important}.margin--big{margin:1.5rem !important}.margin-top-big{margin-top:1.5rem !important}.margin-right-big{margin-right:1.5rem !important}.margin-bottom-big,.table-of-progress .step-header{margin-bottom:1.5rem !important}.margin-left-big{margin-left:1.5rem !important}.margin-horizontal-big{margin-left:1.5rem !important;margin-right:1.5rem !important}.margin-vertical-big{margin-top:1.5rem !important;margin-bottom:1.5rem !important}.margin--bigger{margin:2rem !important}.margin-top-bigger,.card.entry-post.project-index .card-content .content{margin-top:2rem !important}.margin-right-bigger{margin-right:2rem !important}.margin-bottom-bigger{margin-bottom:2rem !important}.margin-left-bigger,.card.blog-entry .blog-content{margin-left:2rem !important}.margin-horizontal-bigger{margin-left:2rem !important;margin-right:2rem !important}.margin-vertical-bigger{margin-top:2rem !important;margin-bottom:2rem !important}.margin--large{margin:2.5rem !important}.margin-top-large{margin-top:2.5rem !important}.margin-right-large{margin-right:2.5rem !important}.margin-bottom-large{margin-bottom:2.5rem !important}.margin-left-large{margin-left:2.5rem !important}.margin-horizontal-large{margin-left:2.5rem !important;margin-right:2.5rem !important}.margin-vertical-large{margin-top:2.5rem !important;margin-bottom:2.5rem !important}.margin--larger{margin:3rem !important}.margin-top-larger{margin-top:3rem !important}.margin-right-larger{margin-right:3rem !important}.margin-bottom-larger{margin-bottom:3rem !important}.margin-left-larger{margin-left:3rem !important}.margin-horizontal-larger{margin-left:3rem !important;margin-right:3rem !important}.margin-vertical-larger{margin-top:3rem !important;margin-bottom:3rem !important}.margin--xl{margin:4rem !important}.margin-top-xl{margin-top:4rem !important}.margin-right-xl{margin-right:4rem !important}.margin-bottom-xl{margin-bottom:4rem !important}.margin-left-xl{margin-left:4rem !important}.margin-horizontal-xl{margin-left:4rem !important;margin-right:4rem !important}.margin-vertical-xl{margin-top:4rem !important;margin-bottom:4rem !important}.margin--xxl{margin:6rem !important}.margin-top-xxl{margin-top:6rem !important}.margin-right-xxl{margin-right:6rem !important}.margin-bottom-xxl{margin-bottom:6rem !important}.margin-left-xxl{margin-left:6rem !important}.margin-horizontal-xxl{margin-left:6rem !important;margin-right:6rem !important}.margin-vertical-xxl{margin-top:6rem !important;margin-bottom:6rem !important}.padding--0{padding:0 !important}.padding-top-0{padding-top:0 !important}.padding-right-0{padding-right:0 !important}.padding-bottom-0{padding-bottom:0 !important}.padding-left-0{padding-left:0 !important}.padding-horizontal-0{padding-left:0 !important;padding-right:0 !important}.padding-vertical-0{padding-top:0 !important;padding-bottom:0 !important}.padding--smaller{padding:.25rem !important}.padding-top-smaller{padding-top:.25rem !important}.padding-right-smaller{padding-right:.25rem !important}.padding-bottom-smaller{padding-bottom:.25rem !important}.padding-left-smaller{padding-left:.25rem !important}.padding-horizontal-smaller,.navbar.is-compact .navbar-end>.navbar-item{padding-left:.25rem !important;padding-right:.25rem !important}.padding-vertical-smaller,.table-of-progress .step .number,.table-of-progress .step .is-active,.table-of-progress .step :hover .number,.table-of-progress .step :hover .is-active,.card.entry-post.project-index .card-content .external-links .button .icon,.card.entry-post.project-index .card-content .site-link .icon{padding-top:.25rem !important;padding-bottom:.25rem !important}.padding--small{padding:.5rem !important}.padding-top-small,.sidebar-menu .menu-list .link{padding-top:.5rem !important}.padding-right-small,.table-of-contents .icon,.sidebar-menu .icon{padding-right:.5rem !important}.padding-bottom-small{padding-bottom:.5rem !important}.padding-left-small{padding-left:.5rem !important}.padding-horizontal-small,.image.is-compact .image-icons,.image .bookmark-icon,.card.entry-post.project-index .card-content .external-links .button .link-content,.card.entry-post.project-index .card-content .site-link .icon{padding-left:.5rem !important;padding-right:.5rem !important}.padding-vertical-small,.image .image-title,.image .image-icons,.image .bookmark-icon,.tabs.is-boxed a{padding-top:.5rem !important;padding-bottom:.5rem !important}.padding--normal{padding:1rem !important}.padding-top-normal,.sidebar-menu{padding-top:1rem !important}.padding-right-normal{padding-right:1rem !important}.padding-bottom-normal{padding-bottom:1rem !important}.padding-left-normal{padding-left:1rem !important}.padding-horizontal-normal,.image .image-icons,.image .image-title,.tabs.is-boxed a{padding-left:1rem !important;padding-right:1rem !important}.padding-vertical-normal,.navbar.is-compact,.notification.is-compact .notification-container{padding-top:1rem !important;padding-bottom:1rem !important}.padding--big{padding:1.5rem !important}.padding-top-big{padding-top:1.5rem !important}.padding-right-big{padding-right:1.5rem !important}.padding-bottom-big,.sidebar-menu{padding-bottom:1.5rem !important}.padding-left-big{padding-left:1.5rem !important}.padding-horizontal-big,.sidebar-menu .menu-list .link{padding-left:1.5rem !important;padding-right:1.5rem !important}.padding-vertical-big{padding-top:1.5rem !important;padding-bottom:1.5rem !important}.padding--bigger{padding:2rem !important}.padding-top-bigger{padding-top:2rem !important}.padding-right-bigger{padding-right:2rem !important}.padding-bottom-bigger{padding-bottom:2rem !important}.padding-left-bigger{padding-left:2rem !important}.padding-horizontal-bigger,.navbar.is-compact{padding-left:2rem !important;padding-right:2rem !important}.padding-vertical-bigger{padding-top:2rem !important;padding-bottom:2rem !important}.padding--large{padding:2.5rem !important}.padding-top-large{padding-top:2.5rem !important}.padding-right-large{padding-right:2.5rem !important}.padding-bottom-large{padding-bottom:2.5rem !important}.padding-left-large{padding-left:2.5rem !important}.padding-horizontal-large{padding-left:2.5rem !important;padding-right:2.5rem !important}.padding-vertical-large{padding-top:2.5rem !important;padding-bottom:2.5rem !important}.padding--larger{padding:3rem !important}.padding-top-larger{padding-top:3rem !important}.padding-right-larger{padding-right:3rem !important}.padding-bottom-larger{padding-bottom:3rem !important}.padding-left-larger{padding-left:3rem !important}.padding-horizontal-larger{padding-left:3rem !important;padding-right:3rem !important}.padding-vertical-larger{padding-top:3rem !important;padding-bottom:3rem !important}.padding--xl{padding:4rem !important}.padding-top-xl{padding-top:4rem !important}.padding-right-xl{padding-right:4rem !important}.padding-bottom-xl{padding-bottom:4rem !important}.padding-left-xl{padding-left:4rem !important}.padding-horizontal-xl{padding-left:4rem !important;padding-right:4rem !important}.padding-vertical-xl{padding-top:4rem !important;padding-bottom:4rem !important}.padding--xxl{padding:6rem !important}.padding-top-xxl{padding-top:6rem !important}.padding-right-xxl{padding-right:6rem !important}.padding-bottom-xxl{padding-bottom:6rem !important}.padding-left-xxl{padding-left:6rem !important}.padding-horizontal-xxl{padding-left:6rem !important;padding-right:6rem !important}.padding-vertical-xxl{padding-top:6rem !important;padding-bottom:6rem !important}.is-size-1{font-size:3.56rem !important}.is-size-2{font-size:2.25rem !important}.is-size-3{font-size:1.75rem !important}.is-size-4{font-size:1.43rem !important}.is-size-5{font-size:1.12rem !important}.is-size-6{font-size:1rem !important}.is-size-7{font-size:.8rem !important}@media screen and (max-width: 768px){.is-size-1-mobile{font-size:3.56rem !important}.is-size-2-mobile{font-size:2.25rem !important}.is-size-3-mobile{font-size:1.75rem !important}.is-size-4-mobile{font-size:1.43rem !important}.is-size-5-mobile{font-size:1.12rem !important}.is-size-6-mobile{font-size:1rem !important}.is-size-7-mobile{font-size:.8rem !important}}@media screen and (min-width: 769px),print{.is-size-1-tablet{font-size:3.56rem !important}.is-size-2-tablet{font-size:2.25rem !important}.is-size-3-tablet{font-size:1.75rem !important}.is-size-4-tablet{font-size:1.43rem !important}.is-size-5-tablet{font-size:1.12rem !important}.is-size-6-tablet{font-size:1rem !important}.is-size-7-tablet{font-size:.8rem !important}}@media screen and (max-width: 1023px){.is-size-1-touch{font-size:3.56rem !important}.is-size-2-touch{font-size:2.25rem !important}.is-size-3-touch{font-size:1.75rem !important}.is-size-4-touch{font-size:1.43rem !important}.is-size-5-touch{font-size:1.12rem !important}.is-size-6-touch{font-size:1rem !important}.is-size-7-touch{font-size:.8rem !important}}@media screen and (min-width: 1024px){.is-size-1-desktop{font-size:3.56rem !important}.is-size-2-desktop{font-size:2.25rem !important}.is-size-3-desktop{font-size:1.75rem !important}.is-size-4-desktop{font-size:1.43rem !important}.is-size-5-desktop{font-size:1.12rem !important}.is-size-6-desktop{font-size:1rem !important}.is-size-7-desktop{font-size:.8rem !important}}@media screen and (min-width: 1216px){.is-size-1-widescreen{font-size:3.56rem !important}.is-size-2-widescreen{font-size:2.25rem !important}.is-size-3-widescreen{font-size:1.75rem !important}.is-size-4-widescreen{font-size:1.43rem !important}.is-size-5-widescreen{font-size:1.12rem !important}.is-size-6-widescreen{font-size:1rem !important}.is-size-7-widescreen{font-size:.8rem !important}}@media screen and (min-width: 1408px){.is-size-1-fullhd{font-size:3.56rem !important}.is-size-2-fullhd{font-size:2.25rem !important}.is-size-3-fullhd{font-size:1.75rem !important}.is-size-4-fullhd{font-size:1.43rem !important}.is-size-5-fullhd{font-size:1.12rem !important}.is-size-6-fullhd{font-size:1rem !important}.is-size-7-fullhd{font-size:.8rem !important}}.has-text-centered,.table-of-progress .step .number,.table-of-progress .step .is-active,.table-of-progress .step :hover .number,.table-of-progress .step :hover .is-active{text-align:center !important}.has-text-justified{text-align:justify !important}.has-text-left{text-align:left !important}.has-text-right{text-align:right !important}@media screen and (max-width: 768px){.has-text-centered-mobile{text-align:center !important}}@media screen and (min-width: 769px),print{.has-text-centered-tablet{text-align:center !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.has-text-centered-tablet-only{text-align:center !important}}@media screen and (max-width: 1023px){.has-text-centered-touch{text-align:center !important}}@media screen and (min-width: 1024px){.has-text-centered-desktop{text-align:center !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.has-text-centered-desktop-only{text-align:center !important}}@media screen and (min-width: 1216px){.has-text-centered-widescreen{text-align:center !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.has-text-centered-widescreen-only{text-align:center !important}}@media screen and (min-width: 1408px){.has-text-centered-fullhd{text-align:center !important}}@media screen and (max-width: 768px){.has-text-justified-mobile{text-align:justify !important}}@media screen and (min-width: 769px),print{.has-text-justified-tablet{text-align:justify !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.has-text-justified-tablet-only{text-align:justify !important}}@media screen and (max-width: 1023px){.has-text-justified-touch{text-align:justify !important}}@media screen and (min-width: 1024px){.has-text-justified-desktop{text-align:justify !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.has-text-justified-desktop-only{text-align:justify !important}}@media screen and (min-width: 1216px){.has-text-justified-widescreen{text-align:justify !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.has-text-justified-widescreen-only{text-align:justify !important}}@media screen and (min-width: 1408px){.has-text-justified-fullhd{text-align:justify !important}}@media screen and (max-width: 768px){.has-text-left-mobile{text-align:left !important}}@media screen and (min-width: 769px),print{.has-text-left-tablet{text-align:left !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.has-text-left-tablet-only{text-align:left !important}}@media screen and (max-width: 1023px){.has-text-left-touch{text-align:left !important}}@media screen and (min-width: 1024px){.has-text-left-desktop{text-align:left !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.has-text-left-desktop-only{text-align:left !important}}@media screen and (min-width: 1216px){.has-text-left-widescreen{text-align:left !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.has-text-left-widescreen-only{text-align:left !important}}@media screen and (min-width: 1408px){.has-text-left-fullhd{text-align:left !important}}@media screen and (max-width: 768px){.has-text-right-mobile{text-align:right !important}}@media screen and (min-width: 769px),print{.has-text-right-tablet{text-align:right !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.has-text-right-tablet-only{text-align:right !important}}@media screen and (max-width: 1023px){.has-text-right-touch{text-align:right !important}}@media screen and (min-width: 1024px){.has-text-right-desktop{text-align:right !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.has-text-right-desktop-only{text-align:right !important}}@media screen and (min-width: 1216px){.has-text-right-widescreen{text-align:right !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.has-text-right-widescreen-only{text-align:right !important}}@media screen and (min-width: 1408px){.has-text-right-fullhd{text-align:right !important}}.is-capitalized{text-transform:capitalize !important}.is-lowercase{text-transform:lowercase !important}.is-uppercase{text-transform:uppercase !important}.is-italic{font-style:italic !important}.has-text-weight-light{font-weight:300 !important}.has-text-weight-normal{font-weight:400 !important}.has-text-weight-medium{font-weight:500 !important}.has-text-weight-semibold{font-weight:600 !important}.has-text-weight-bold{font-weight:700 !important}.is-family-primary{font-family:"Source Sans Pro",sans-serif !important}.is-family-secondary{font-family:"Roboto Condensed",sans-serif !important}.is-family-sans-serif{font-family:"Source Sans Pro",sans-serif !important}.is-family-monospace{font-family:"JetBrains Mono",monospace !important}.is-family-code{font-family:"JetBrains Mono",monospace !important}.is-block{display:block !important}@media screen and (max-width: 768px){.is-block-mobile{display:block !important}}@media screen and (min-width: 769px),print{.is-block-tablet{display:block !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-block-tablet-only{display:block !important}}@media screen and (max-width: 1023px){.is-block-touch{display:block !important}}@media screen and (min-width: 1024px){.is-block-desktop{display:block !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-block-desktop-only{display:block !important}}@media screen and (min-width: 1216px){.is-block-widescreen{display:block !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-block-widescreen-only{display:block !important}}@media screen and (min-width: 1408px){.is-block-fullhd{display:block !important}}.is-flex{display:flex !important}@media screen and (max-width: 768px){.is-flex-mobile{display:flex !important}}@media screen and (min-width: 769px),print{.is-flex-tablet{display:flex !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-flex-tablet-only{display:flex !important}}@media screen and (max-width: 1023px){.is-flex-touch{display:flex !important}}@media screen and (min-width: 1024px){.is-flex-desktop{display:flex !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-flex-desktop-only{display:flex !important}}@media screen and (min-width: 1216px){.is-flex-widescreen{display:flex !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-flex-widescreen-only{display:flex !important}}@media screen and (min-width: 1408px){.is-flex-fullhd{display:flex !important}}.is-inline{display:inline !important}@media screen and (max-width: 768px){.is-inline-mobile{display:inline !important}}@media screen and (min-width: 769px),print{.is-inline-tablet{display:inline !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-inline-tablet-only{display:inline !important}}@media screen and (max-width: 1023px){.is-inline-touch{display:inline !important}}@media screen and (min-width: 1024px){.is-inline-desktop{display:inline !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-inline-desktop-only{display:inline !important}}@media screen and (min-width: 1216px){.is-inline-widescreen{display:inline !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-inline-widescreen-only{display:inline !important}}@media screen and (min-width: 1408px){.is-inline-fullhd{display:inline !important}}.is-inline-block{display:inline-block !important}@media screen and (max-width: 768px){.is-inline-block-mobile{display:inline-block !important}}@media screen and (min-width: 769px),print{.is-inline-block-tablet{display:inline-block !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-inline-block-tablet-only{display:inline-block !important}}@media screen and (max-width: 1023px){.is-inline-block-touch{display:inline-block !important}}@media screen and (min-width: 1024px){.is-inline-block-desktop{display:inline-block !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-inline-block-desktop-only{display:inline-block !important}}@media screen and (min-width: 1216px){.is-inline-block-widescreen{display:inline-block !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-inline-block-widescreen-only{display:inline-block !important}}@media screen and (min-width: 1408px){.is-inline-block-fullhd{display:inline-block !important}}.is-inline-flex{display:inline-flex !important}@media screen and (max-width: 768px){.is-inline-flex-mobile{display:inline-flex !important}}@media screen and (min-width: 769px),print{.is-inline-flex-tablet{display:inline-flex !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-inline-flex-tablet-only{display:inline-flex !important}}@media screen and (max-width: 1023px){.is-inline-flex-touch{display:inline-flex !important}}@media screen and (min-width: 1024px){.is-inline-flex-desktop{display:inline-flex !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-inline-flex-desktop-only{display:inline-flex !important}}@media screen and (min-width: 1216px){.is-inline-flex-widescreen{display:inline-flex !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-inline-flex-widescreen-only{display:inline-flex !important}}@media screen and (min-width: 1408px){.is-inline-flex-fullhd{display:inline-flex !important}}.is-hidden{display:none !important}.is-sr-only{border:none !important;clip:rect(0, 0, 0, 0) !important;height:.01em !important;overflow:hidden !important;padding:0 !important;position:absolute !important;white-space:nowrap !important;width:.01em !important}@media screen and (max-width: 768px){.is-hidden-mobile{display:none !important}}@media screen and (min-width: 769px),print{.is-hidden-tablet{display:none !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-hidden-tablet-only{display:none !important}}@media screen and (max-width: 1023px){.is-hidden-touch{display:none !important}}@media screen and (min-width: 1024px){.is-hidden-desktop{display:none !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-hidden-desktop-only{display:none !important}}@media screen and (min-width: 1216px){.is-hidden-widescreen{display:none !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-hidden-widescreen-only{display:none !important}}@media screen and (min-width: 1408px){.is-hidden-fullhd{display:none !important}}.is-invisible{visibility:hidden !important}@media screen and (max-width: 768px){.is-invisible-mobile{visibility:hidden !important}}@media screen and (min-width: 769px),print{.is-invisible-tablet{visibility:hidden !important}}@media screen and (min-width: 769px)and (max-width: 1023px){.is-invisible-tablet-only{visibility:hidden !important}}@media screen and (max-width: 1023px){.is-invisible-touch{visibility:hidden !important}}@media screen and (min-width: 1024px){.is-invisible-desktop{visibility:hidden !important}}@media screen and (min-width: 1024px)and (max-width: 1215px){.is-invisible-desktop-only{visibility:hidden !important}}@media screen and (min-width: 1216px){.is-invisible-widescreen{visibility:hidden !important}}@media screen and (min-width: 1216px)and (max-width: 1407px){.is-invisible-widescreen-only{visibility:hidden !important}}@media screen and (min-width: 1408px){.is-invisible-fullhd{visibility:hidden !important}}html{background-color:#fff;font-size:16px;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;min-width:300px;overflow-x:hidden;overflow-y:scroll;text-rendering:optimizeLegibility;text-size-adjust:100%}article,aside,figure,footer,header,hgroup,section{display:block}body,button,input,optgroup,select,textarea{font-family:"Source Sans Pro",sans-serif}code,pre{-moz-osx-font-smoothing:auto;-webkit-font-smoothing:auto;font-family:"JetBrains Mono",monospace}body{color:#767676;font-size:1em;font-weight:400;line-height:1.5}a{color:#e23600;cursor:pointer;text-decoration:none}a strong{color:currentColor}a:hover{color:currentColor}code{background-color:#f5f5f5;color:#962400;font-size:.875em;font-weight:normal;padding:.25em .5em .25em}hr{background-color:#f5f5f5;border:none;display:block;height:2px;margin:1.5rem 0}img{height:auto;max-width:100%}input[type=checkbox],input[type=radio]{vertical-align:baseline}small{font-size:.875em}span{font-style:inherit;font-weight:inherit}strong{color:#363636;font-weight:700}fieldset{border:none}pre{-webkit-overflow-scrolling:touch;background-color:#f5f5f5;color:#767676;font-size:.875em;overflow-x:auto;padding:1.25rem 1.5rem;white-space:pre;word-wrap:normal}pre code{background-color:rgba(0,0,0,0);color:currentColor;font-size:1em;padding:0}table td,table th{vertical-align:top}table td:not([align]),table th:not([align]){text-align:inherit}table th{color:#363636}.button{background-color:#fff;border-color:#f5f5f5;border-width:1px;color:#363636;cursor:pointer;font-family:"Roboto Condensed",sans-serif;justify-content:center;padding-bottom:calc(.5em - 1px);padding-left:1em;padding-right:1em;padding-top:calc(.5em - 1px);text-align:center;white-space:nowrap}.button strong{color:inherit}.button .icon,.button .icon.is-small,.button .icon.is-medium,.button .icon.is-large{height:1.5em;width:1.5em}.button .icon:first-child:not(:last-child){margin-left:calc(-0.5em - 1px);margin-right:.25em}.button .icon:last-child:not(:first-child){margin-left:.25em;margin-right:calc(-0.5em - 1px)}.button .icon:first-child:last-child{margin-left:calc(-0.5em - 1px);margin-right:calc(-0.5em - 1px)}.button:hover,.button.is-hovered{border-color:#d8d8d8;color:currentColor}.button:focus,.button.is-focused{border-color:#3c5c99;color:#363636}.button:focus:not(:active),.button.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.button:active,.button.is-active,.table-of-progress .step :hover .button.number,.table-of-progress .step :hover .button.is-active{border-color:#767676;color:#363636}.button.is-text{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0);color:#767676;text-decoration:underline}.button.is-text:hover,.button.is-text.is-hovered,.button.is-text:focus,.button.is-text.is-focused{background-color:#f5f5f5;color:#363636}.button.is-text:active,.button.is-text.is-active,.table-of-progress .step :hover .button.is-text.number,.table-of-progress .step :hover .button.is-text.is-active{background-color:#e8e8e8;color:#363636}.button.is-text[disabled],fieldset[disabled] .button.is-text{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0);box-shadow:none}.button.is-white{background-color:#fff;border-color:rgba(0,0,0,0);color:#000}.button.is-white:hover,.button.is-white.is-hovered{background-color:#f9f9f9;border-color:rgba(0,0,0,0);color:#000}.button.is-white:focus,.button.is-white.is-focused{border-color:rgba(0,0,0,0);color:#000}.button.is-white:focus:not(:active),.button.is-white.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(255,255,255,.25)}.button.is-white:active,.button.is-white.is-active,.table-of-progress .step :hover .button.is-white.number,.table-of-progress .step :hover .button.is-white.is-active{background-color:#f2f2f2;border-color:rgba(0,0,0,0);color:#000}.button.is-white[disabled],fieldset[disabled] .button.is-white{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-white.is-inverted{background-color:#000;color:#fff}.button.is-white.is-inverted:hover,.button.is-white.is-inverted.is-hovered{background-color:#000}.button.is-white.is-inverted[disabled],fieldset[disabled] .button.is-white.is-inverted{background-color:#000;border-color:rgba(0,0,0,0);box-shadow:none;color:#fff}.button.is-white.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #000 #000 !important}.button.is-white.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-white.is-outlined:hover,.button.is-white.is-outlined.is-hovered,.button.is-white.is-outlined:focus,.button.is-white.is-outlined.is-focused{background-color:#fff;border-color:#fff;color:#000}.button.is-white.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-white.is-outlined.is-loading:hover::after,.button.is-white.is-outlined.is-loading.is-hovered::after,.button.is-white.is-outlined.is-loading:focus::after,.button.is-white.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #000 #000 !important}.button.is-white.is-outlined[disabled],fieldset[disabled] .button.is-white.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-white.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#000;color:#000}.button.is-white.is-inverted.is-outlined:hover,.button.is-white.is-inverted.is-outlined.is-hovered,.button.is-white.is-inverted.is-outlined:focus,.button.is-white.is-inverted.is-outlined.is-focused{background-color:#000;color:#fff}.button.is-white.is-inverted.is-outlined.is-loading:hover::after,.button.is-white.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-white.is-inverted.is-outlined.is-loading:focus::after,.button.is-white.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-white.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-white.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#000;box-shadow:none;color:#000}.button.is-black{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.button.is-black:hover,.button.is-black.is-hovered{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.button.is-black:focus,.button.is-black.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-black:focus:not(:active),.button.is-black.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(0,0,0,.25)}.button.is-black:active,.button.is-black.is-active,.table-of-progress .step :hover .button.is-black.number,.table-of-progress .step :hover .button.is-black.is-active{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.button.is-black[disabled],fieldset[disabled] .button.is-black{background-color:#000;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-black.is-inverted{background-color:#fff;color:#000}.button.is-black.is-inverted:hover,.button.is-black.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-black.is-inverted[disabled],fieldset[disabled] .button.is-black.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#000}.button.is-black.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-black.is-outlined{background-color:rgba(0,0,0,0);border-color:#000;color:#000}.button.is-black.is-outlined:hover,.button.is-black.is-outlined.is-hovered,.button.is-black.is-outlined:focus,.button.is-black.is-outlined.is-focused{background-color:#000;border-color:#000;color:#fff}.button.is-black.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #000 #000 !important}.button.is-black.is-outlined.is-loading:hover::after,.button.is-black.is-outlined.is-loading.is-hovered::after,.button.is-black.is-outlined.is-loading:focus::after,.button.is-black.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-black.is-outlined[disabled],fieldset[disabled] .button.is-black.is-outlined{background-color:rgba(0,0,0,0);border-color:#000;box-shadow:none;color:#000}.button.is-black.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-black.is-inverted.is-outlined:hover,.button.is-black.is-inverted.is-outlined.is-hovered,.button.is-black.is-inverted.is-outlined:focus,.button.is-black.is-inverted.is-outlined.is-focused{background-color:#fff;color:#000}.button.is-black.is-inverted.is-outlined.is-loading:hover::after,.button.is-black.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-black.is-inverted.is-outlined.is-loading:focus::after,.button.is-black.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #000 #000 !important}.button.is-black.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-black.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-light{background-color:#f5f5f5;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.button.is-light:hover,.button.is-light.is-hovered{background-color:#eee;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.button.is-light:focus,.button.is-light.is-focused{border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.button.is-light:focus:not(:active),.button.is-light.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(245,245,245,.25)}.button.is-light:active,.button.is-light.is-active,.table-of-progress .step :hover .button.is-light.number,.table-of-progress .step :hover .button.is-light.is-active{background-color:#e8e8e8;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.button.is-light[disabled],fieldset[disabled] .button.is-light{background-color:#f5f5f5;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-light.is-inverted{background-color:rgba(0,0,0,.7);color:#f5f5f5}.button.is-light.is-inverted:hover,.button.is-light.is-inverted.is-hovered{background-color:rgba(0,0,0,.7)}.button.is-light.is-inverted[disabled],fieldset[disabled] .button.is-light.is-inverted{background-color:rgba(0,0,0,.7);border-color:rgba(0,0,0,0);box-shadow:none;color:#f5f5f5}.button.is-light.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) rgba(0,0,0,.7) rgba(0,0,0,.7) !important}.button.is-light.is-outlined{background-color:rgba(0,0,0,0);border-color:#f5f5f5;color:#f5f5f5}.button.is-light.is-outlined:hover,.button.is-light.is-outlined.is-hovered,.button.is-light.is-outlined:focus,.button.is-light.is-outlined.is-focused{background-color:#f5f5f5;border-color:#f5f5f5;color:rgba(0,0,0,.7)}.button.is-light.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #f5f5f5 #f5f5f5 !important}.button.is-light.is-outlined.is-loading:hover::after,.button.is-light.is-outlined.is-loading.is-hovered::after,.button.is-light.is-outlined.is-loading:focus::after,.button.is-light.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) rgba(0,0,0,.7) rgba(0,0,0,.7) !important}.button.is-light.is-outlined[disabled],fieldset[disabled] .button.is-light.is-outlined{background-color:rgba(0,0,0,0);border-color:#f5f5f5;box-shadow:none;color:#f5f5f5}.button.is-light.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,.7);color:rgba(0,0,0,.7)}.button.is-light.is-inverted.is-outlined:hover,.button.is-light.is-inverted.is-outlined.is-hovered,.button.is-light.is-inverted.is-outlined:focus,.button.is-light.is-inverted.is-outlined.is-focused{background-color:rgba(0,0,0,.7);color:#f5f5f5}.button.is-light.is-inverted.is-outlined.is-loading:hover::after,.button.is-light.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-light.is-inverted.is-outlined.is-loading:focus::after,.button.is-light.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #f5f5f5 #f5f5f5 !important}.button.is-light.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-light.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,.7);box-shadow:none;color:rgba(0,0,0,.7)}.button.is-dark{background-color:#363636;border-color:rgba(0,0,0,0);color:#fff}.button.is-dark:hover,.button.is-dark.is-hovered{background-color:#2f2f2f;border-color:rgba(0,0,0,0);color:#fff}.button.is-dark:focus,.button.is-dark.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-dark:focus:not(:active),.button.is-dark.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(54,54,54,.25)}.button.is-dark:active,.button.is-dark.is-active,.table-of-progress .step :hover .button.is-dark.number,.table-of-progress .step :hover .button.is-dark.is-active{background-color:#292929;border-color:rgba(0,0,0,0);color:#fff}.button.is-dark[disabled],fieldset[disabled] .button.is-dark{background-color:#363636;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-dark.is-inverted{background-color:#fff;color:#363636}.button.is-dark.is-inverted:hover,.button.is-dark.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-dark.is-inverted[disabled],fieldset[disabled] .button.is-dark.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#363636}.button.is-dark.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-dark.is-outlined{background-color:rgba(0,0,0,0);border-color:#363636;color:#363636}.button.is-dark.is-outlined:hover,.button.is-dark.is-outlined.is-hovered,.button.is-dark.is-outlined:focus,.button.is-dark.is-outlined.is-focused{background-color:#363636;border-color:#363636;color:#fff}.button.is-dark.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #363636 #363636 !important}.button.is-dark.is-outlined.is-loading:hover::after,.button.is-dark.is-outlined.is-loading.is-hovered::after,.button.is-dark.is-outlined.is-loading:focus::after,.button.is-dark.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-dark.is-outlined[disabled],fieldset[disabled] .button.is-dark.is-outlined{background-color:rgba(0,0,0,0);border-color:#363636;box-shadow:none;color:#363636}.button.is-dark.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-dark.is-inverted.is-outlined:hover,.button.is-dark.is-inverted.is-outlined.is-hovered,.button.is-dark.is-inverted.is-outlined:focus,.button.is-dark.is-inverted.is-outlined.is-focused{background-color:#fff;color:#363636}.button.is-dark.is-inverted.is-outlined.is-loading:hover::after,.button.is-dark.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-dark.is-inverted.is-outlined.is-loading:focus::after,.button.is-dark.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #363636 #363636 !important}.button.is-dark.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-dark.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-primary{background-color:#e23600;border-color:rgba(0,0,0,0);color:#fff}.button.is-primary:hover,.button.is-primary.is-hovered{background-color:#d53300;border-color:rgba(0,0,0,0);color:#fff}.button.is-primary:focus,.button.is-primary.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-primary:focus:not(:active),.button.is-primary.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.button.is-primary:active,.button.is-primary.is-active,.table-of-progress .step :hover .button.is-primary.number,.table-of-progress .step :hover .button.is-primary.is-active{background-color:#c93000;border-color:rgba(0,0,0,0);color:#fff}.button.is-primary[disabled],fieldset[disabled] .button.is-primary{background-color:#e23600;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-primary.is-inverted{background-color:#fff;color:#e23600}.button.is-primary.is-inverted:hover,.button.is-primary.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-primary.is-inverted[disabled],fieldset[disabled] .button.is-primary.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#e23600}.button.is-primary.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-primary.is-outlined{background-color:rgba(0,0,0,0);border-color:#e23600;color:#e23600}.button.is-primary.is-outlined:hover,.button.is-primary.is-outlined.is-hovered,.button.is-primary.is-outlined:focus,.button.is-primary.is-outlined.is-focused{background-color:#e23600;border-color:#e23600;color:#fff}.button.is-primary.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #e23600 #e23600 !important}.button.is-primary.is-outlined.is-loading:hover::after,.button.is-primary.is-outlined.is-loading.is-hovered::after,.button.is-primary.is-outlined.is-loading:focus::after,.button.is-primary.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-primary.is-outlined[disabled],fieldset[disabled] .button.is-primary.is-outlined{background-color:rgba(0,0,0,0);border-color:#e23600;box-shadow:none;color:#e23600}.button.is-primary.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-primary.is-inverted.is-outlined:hover,.button.is-primary.is-inverted.is-outlined.is-hovered,.button.is-primary.is-inverted.is-outlined:focus,.button.is-primary.is-inverted.is-outlined.is-focused{background-color:#fff;color:#e23600}.button.is-primary.is-inverted.is-outlined.is-loading:hover::after,.button.is-primary.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-primary.is-inverted.is-outlined.is-loading:focus::after,.button.is-primary.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #e23600 #e23600 !important}.button.is-primary.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-primary.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-primary.is-light{background-color:#ffefeb;color:#eb3800}.button.is-primary.is-light:hover,.button.is-primary.is-light.is-hovered{background-color:#ffe6de;border-color:rgba(0,0,0,0);color:#eb3800}.button.is-primary.is-light:active,.button.is-primary.is-light.is-active,.table-of-progress .step :hover .button.is-primary.is-light.number{background-color:#ffdcd1;border-color:rgba(0,0,0,0);color:#eb3800}.button.is-link{background-color:#e23600;border-color:rgba(0,0,0,0);color:#fff}.button.is-link:hover,.button.is-link.is-hovered{background-color:#d53300;border-color:rgba(0,0,0,0);color:#fff}.button.is-link:focus,.button.is-link.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-link:focus:not(:active),.button.is-link.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.button.is-link:active,.button.is-link.is-active,.table-of-progress .step :hover .button.is-link.number,.table-of-progress .step :hover .button.is-link.is-active{background-color:#c93000;border-color:rgba(0,0,0,0);color:#fff}.button.is-link[disabled],fieldset[disabled] .button.is-link{background-color:#e23600;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-link.is-inverted{background-color:#fff;color:#e23600}.button.is-link.is-inverted:hover,.button.is-link.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-link.is-inverted[disabled],fieldset[disabled] .button.is-link.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#e23600}.button.is-link.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-link.is-outlined{background-color:rgba(0,0,0,0);border-color:#e23600;color:#e23600}.button.is-link.is-outlined:hover,.button.is-link.is-outlined.is-hovered,.button.is-link.is-outlined:focus,.button.is-link.is-outlined.is-focused{background-color:#e23600;border-color:#e23600;color:#fff}.button.is-link.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #e23600 #e23600 !important}.button.is-link.is-outlined.is-loading:hover::after,.button.is-link.is-outlined.is-loading.is-hovered::after,.button.is-link.is-outlined.is-loading:focus::after,.button.is-link.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-link.is-outlined[disabled],fieldset[disabled] .button.is-link.is-outlined{background-color:rgba(0,0,0,0);border-color:#e23600;box-shadow:none;color:#e23600}.button.is-link.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-link.is-inverted.is-outlined:hover,.button.is-link.is-inverted.is-outlined.is-hovered,.button.is-link.is-inverted.is-outlined:focus,.button.is-link.is-inverted.is-outlined.is-focused{background-color:#fff;color:#e23600}.button.is-link.is-inverted.is-outlined.is-loading:hover::after,.button.is-link.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-link.is-inverted.is-outlined.is-loading:focus::after,.button.is-link.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #e23600 #e23600 !important}.button.is-link.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-link.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-link.is-light{background-color:#ffefeb;color:#eb3800}.button.is-link.is-light:hover,.button.is-link.is-light.is-hovered{background-color:#ffe6de;border-color:rgba(0,0,0,0);color:#eb3800}.button.is-link.is-light:active,.button.is-link.is-light.is-active,.table-of-progress .step :hover .button.is-link.is-light.number{background-color:#ffdcd1;border-color:rgba(0,0,0,0);color:#eb3800}.button.is-info{background-color:#1950b8;border-color:rgba(0,0,0,0);color:#fff}.button.is-info:hover,.button.is-info.is-hovered{background-color:#174bad;border-color:rgba(0,0,0,0);color:#fff}.button.is-info:focus,.button.is-info.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-info:focus:not(:active),.button.is-info.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(25,80,184,.25)}.button.is-info:active,.button.is-info.is-active,.table-of-progress .step :hover .button.is-info.number,.table-of-progress .step :hover .button.is-info.is-active{background-color:#1646a2;border-color:rgba(0,0,0,0);color:#fff}.button.is-info[disabled],fieldset[disabled] .button.is-info{background-color:#1950b8;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-info.is-inverted{background-color:#fff;color:#1950b8}.button.is-info.is-inverted:hover,.button.is-info.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-info.is-inverted[disabled],fieldset[disabled] .button.is-info.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#1950b8}.button.is-info.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-info.is-outlined{background-color:rgba(0,0,0,0);border-color:#1950b8;color:#1950b8}.button.is-info.is-outlined:hover,.button.is-info.is-outlined.is-hovered,.button.is-info.is-outlined:focus,.button.is-info.is-outlined.is-focused{background-color:#1950b8;border-color:#1950b8;color:#fff}.button.is-info.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #1950b8 #1950b8 !important}.button.is-info.is-outlined.is-loading:hover::after,.button.is-info.is-outlined.is-loading.is-hovered::after,.button.is-info.is-outlined.is-loading:focus::after,.button.is-info.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-info.is-outlined[disabled],fieldset[disabled] .button.is-info.is-outlined{background-color:rgba(0,0,0,0);border-color:#1950b8;box-shadow:none;color:#1950b8}.button.is-info.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-info.is-inverted.is-outlined:hover,.button.is-info.is-inverted.is-outlined.is-hovered,.button.is-info.is-inverted.is-outlined:focus,.button.is-info.is-inverted.is-outlined.is-focused{background-color:#fff;color:#1950b8}.button.is-info.is-inverted.is-outlined.is-loading:hover::after,.button.is-info.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-info.is-inverted.is-outlined.is-loading:focus::after,.button.is-info.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #1950b8 #1950b8 !important}.button.is-info.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-info.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-info.is-light{background-color:#d1dcf1;color:#1950b8}.button.is-info.is-light:hover,.button.is-info.is-light.is-hovered{background-color:#c7d5ee;border-color:rgba(0,0,0,0);color:#1950b8}.button.is-info.is-light:active,.button.is-info.is-light.is-active,.table-of-progress .step :hover .button.is-info.is-light.number{background-color:#bdcdeb;border-color:rgba(0,0,0,0);color:#1950b8}.button.is-success{background-color:#008300;border-color:rgba(0,0,0,0);color:#fff}.button.is-success:hover,.button.is-success.is-hovered{background-color:#007600;border-color:rgba(0,0,0,0);color:#fff}.button.is-success:focus,.button.is-success.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-success:focus:not(:active),.button.is-success.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(0,131,0,.25)}.button.is-success:active,.button.is-success.is-active,.table-of-progress .step :hover .button.is-success.number,.table-of-progress .step :hover .button.is-success.is-active{background-color:#006a00;border-color:rgba(0,0,0,0);color:#fff}.button.is-success[disabled],fieldset[disabled] .button.is-success{background-color:#008300;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-success.is-inverted{background-color:#fff;color:#008300}.button.is-success.is-inverted:hover,.button.is-success.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-success.is-inverted[disabled],fieldset[disabled] .button.is-success.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#008300}.button.is-success.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-success.is-outlined{background-color:rgba(0,0,0,0);border-color:#008300;color:#008300}.button.is-success.is-outlined:hover,.button.is-success.is-outlined.is-hovered,.button.is-success.is-outlined:focus,.button.is-success.is-outlined.is-focused{background-color:#008300;border-color:#008300;color:#fff}.button.is-success.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #008300 #008300 !important}.button.is-success.is-outlined.is-loading:hover::after,.button.is-success.is-outlined.is-loading.is-hovered::after,.button.is-success.is-outlined.is-loading:focus::after,.button.is-success.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-success.is-outlined[disabled],fieldset[disabled] .button.is-success.is-outlined{background-color:rgba(0,0,0,0);border-color:#008300;box-shadow:none;color:#008300}.button.is-success.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-success.is-inverted.is-outlined:hover,.button.is-success.is-inverted.is-outlined.is-hovered,.button.is-success.is-inverted.is-outlined:focus,.button.is-success.is-inverted.is-outlined.is-focused{background-color:#fff;color:#008300}.button.is-success.is-inverted.is-outlined.is-loading:hover::after,.button.is-success.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-success.is-inverted.is-outlined.is-loading:focus::after,.button.is-success.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #008300 #008300 !important}.button.is-success.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-success.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-success.is-light{background-color:#e0f2bf;color:#008300}.button.is-success.is-light:hover,.button.is-success.is-light.is-hovered{background-color:#dbf0b4;border-color:rgba(0,0,0,0);color:#008300}.button.is-success.is-light:active,.button.is-success.is-light.is-active,.table-of-progress .step :hover .button.is-success.is-light.number{background-color:#d6eeaa;border-color:rgba(0,0,0,0);color:#008300}.button.is-warning{background-color:#f2ab20;border-color:rgba(0,0,0,0);color:#fff}.button.is-warning:hover,.button.is-warning.is-hovered{background-color:#f1a614;border-color:rgba(0,0,0,0);color:#fff}.button.is-warning:focus,.button.is-warning.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-warning:focus:not(:active),.button.is-warning.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(242,171,32,.25)}.button.is-warning:active,.button.is-warning.is-active,.table-of-progress .step :hover .button.is-warning.number,.table-of-progress .step :hover .button.is-warning.is-active{background-color:#eba00e;border-color:rgba(0,0,0,0);color:#fff}.button.is-warning[disabled],fieldset[disabled] .button.is-warning{background-color:#f2ab20;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-warning.is-inverted{background-color:#fff;color:#f2ab20}.button.is-warning.is-inverted:hover,.button.is-warning.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-warning.is-inverted[disabled],fieldset[disabled] .button.is-warning.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#f2ab20}.button.is-warning.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-warning.is-outlined{background-color:rgba(0,0,0,0);border-color:#f2ab20;color:#f2ab20}.button.is-warning.is-outlined:hover,.button.is-warning.is-outlined.is-hovered,.button.is-warning.is-outlined:focus,.button.is-warning.is-outlined.is-focused{background-color:#f2ab20;border-color:#f2ab20;color:#fff}.button.is-warning.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #f2ab20 #f2ab20 !important}.button.is-warning.is-outlined.is-loading:hover::after,.button.is-warning.is-outlined.is-loading.is-hovered::after,.button.is-warning.is-outlined.is-loading:focus::after,.button.is-warning.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-warning.is-outlined[disabled],fieldset[disabled] .button.is-warning.is-outlined{background-color:rgba(0,0,0,0);border-color:#f2ab20;box-shadow:none;color:#f2ab20}.button.is-warning.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-warning.is-inverted.is-outlined:hover,.button.is-warning.is-inverted.is-outlined.is-hovered,.button.is-warning.is-inverted.is-outlined:focus,.button.is-warning.is-inverted.is-outlined.is-focused{background-color:#fff;color:#f2ab20}.button.is-warning.is-inverted.is-outlined.is-loading:hover::after,.button.is-warning.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-warning.is-inverted.is-outlined.is-loading:focus::after,.button.is-warning.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #f2ab20 #f2ab20 !important}.button.is-warning.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-warning.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-warning.is-light{background-color:#faecbc;color:#f2ab20}.button.is-warning.is-light:hover,.button.is-warning.is-light.is-hovered{background-color:#f9e9b0;border-color:rgba(0,0,0,0);color:#f2ab20}.button.is-warning.is-light:active,.button.is-warning.is-light.is-active,.table-of-progress .step :hover .button.is-warning.is-light.number{background-color:#f8e5a4;border-color:rgba(0,0,0,0);color:#f2ab20}.button.is-danger{background-color:#c83b1e;border-color:rgba(0,0,0,0);color:#fff}.button.is-danger:hover,.button.is-danger.is-hovered{background-color:#bd381c;border-color:rgba(0,0,0,0);color:#fff}.button.is-danger:focus,.button.is-danger.is-focused{border-color:rgba(0,0,0,0);color:#fff}.button.is-danger:focus:not(:active),.button.is-danger.is-focused:not(:active){box-shadow:0 0 0 .125em rgba(200,59,30,.25)}.button.is-danger:active,.button.is-danger.is-active,.table-of-progress .step :hover .button.is-danger.number,.table-of-progress .step :hover .button.is-danger.is-active{background-color:#b2341b;border-color:rgba(0,0,0,0);color:#fff}.button.is-danger[disabled],fieldset[disabled] .button.is-danger{background-color:#c83b1e;border-color:rgba(0,0,0,0);box-shadow:none}.button.is-danger.is-inverted{background-color:#fff;color:#c83b1e}.button.is-danger.is-inverted:hover,.button.is-danger.is-inverted.is-hovered{background-color:#f2f2f2}.button.is-danger.is-inverted[disabled],fieldset[disabled] .button.is-danger.is-inverted{background-color:#fff;border-color:rgba(0,0,0,0);box-shadow:none;color:#c83b1e}.button.is-danger.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-danger.is-outlined{background-color:rgba(0,0,0,0);border-color:#c83b1e;color:#c83b1e}.button.is-danger.is-outlined:hover,.button.is-danger.is-outlined.is-hovered,.button.is-danger.is-outlined:focus,.button.is-danger.is-outlined.is-focused{background-color:#c83b1e;border-color:#c83b1e;color:#fff}.button.is-danger.is-outlined.is-loading::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #c83b1e #c83b1e !important}.button.is-danger.is-outlined.is-loading:hover::after,.button.is-danger.is-outlined.is-loading.is-hovered::after,.button.is-danger.is-outlined.is-loading:focus::after,.button.is-danger.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #fff #fff !important}.button.is-danger.is-outlined[disabled],fieldset[disabled] .button.is-danger.is-outlined{background-color:rgba(0,0,0,0);border-color:#c83b1e;box-shadow:none;color:#c83b1e}.button.is-danger.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;color:#fff}.button.is-danger.is-inverted.is-outlined:hover,.button.is-danger.is-inverted.is-outlined.is-hovered,.button.is-danger.is-inverted.is-outlined:focus,.button.is-danger.is-inverted.is-outlined.is-focused{background-color:#fff;color:#c83b1e}.button.is-danger.is-inverted.is-outlined.is-loading:hover::after,.button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after,.button.is-danger.is-inverted.is-outlined.is-loading:focus::after,.button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after{border-color:rgba(0,0,0,0) rgba(0,0,0,0) #c83b1e #c83b1e !important}.button.is-danger.is-inverted.is-outlined[disabled],fieldset[disabled] .button.is-danger.is-inverted.is-outlined{background-color:rgba(0,0,0,0);border-color:#fff;box-shadow:none;color:#fff}.button.is-danger.is-light{background-color:#ffc9c9;color:#c83b1e}.button.is-danger.is-light:hover,.button.is-danger.is-light.is-hovered{background-color:#ffbcbc;border-color:rgba(0,0,0,0);color:#c83b1e}.button.is-danger.is-light:active,.button.is-danger.is-light.is-active,.table-of-progress .step :hover .button.is-danger.is-light.number{background-color:#ffb0b0;border-color:rgba(0,0,0,0);color:#c83b1e}.button.is-small{border-radius:2px;font-size:.8rem}.button.is-normal{font-size:1rem}.button.is-medium{font-size:1.12rem}.button.is-large{font-size:1.43rem}.button[disabled],fieldset[disabled] .button{background-color:#fff;border-color:#f5f5f5;box-shadow:none;opacity:.5}.button.is-fullwidth{display:flex;width:100%}.button.is-loading{color:rgba(0,0,0,0) !important;pointer-events:none}.button.is-loading::after{position:absolute;left:calc(50% - 1em/2);top:calc(50% - 1em/2);position:absolute !important}.button.is-static{background-color:#f5f5f5;border-color:#f5f5f5;color:#b0b0b0;box-shadow:none;pointer-events:none}.button.is-rounded,.image .button.profile{border-radius:290486px;padding-left:calc(1em + .25em);padding-right:calc(1em + .25em)}.buttons{align-items:center;display:flex;flex-wrap:wrap;justify-content:flex-start}.buttons .button{margin-bottom:.5rem}.buttons .button:not(:last-child):not(.is-fullwidth){margin-right:.5rem}.buttons:last-child{margin-bottom:-0.5rem}.buttons:not(:last-child){margin-bottom:1rem}.buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large){border-radius:2px;font-size:.8rem}.buttons.are-medium .button:not(.is-small):not(.is-normal):not(.is-large){font-size:1.12rem}.buttons.are-large .button:not(.is-small):not(.is-normal):not(.is-medium){font-size:1.43rem}.buttons.has-addons .button:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}.buttons.has-addons .button:not(:last-child){border-bottom-right-radius:0;border-top-right-radius:0;margin-right:-1px}.buttons.has-addons .button:last-child{margin-right:0}.buttons.has-addons .button:hover,.buttons.has-addons .button.is-hovered{z-index:2}.buttons.has-addons .button:focus,.buttons.has-addons .button.is-focused,.buttons.has-addons .button:active,.buttons.has-addons .button.is-active,.buttons.has-addons .table-of-progress .step :hover .button.number,.table-of-progress .step :hover .buttons.has-addons .button.number,.buttons.has-addons .button.is-selected{z-index:3}.buttons.has-addons .button:focus:hover,.buttons.has-addons .button.is-focused:hover,.buttons.has-addons .button:active:hover,.buttons.has-addons .button.is-active:hover,.buttons.has-addons .table-of-progress .step :hover .button.number:hover,.table-of-progress .step :hover .buttons.has-addons .button.number:hover,.buttons.has-addons .button.is-selected:hover{z-index:4}.buttons.has-addons .button.is-expanded{flex-grow:1;flex-shrink:1}.buttons.is-centered{justify-content:center}.buttons.is-centered:not(.has-addons) .button:not(.is-fullwidth){margin-left:.25rem;margin-right:.25rem}.buttons.is-right{justify-content:flex-end}.buttons.is-right:not(.has-addons) .button:not(.is-fullwidth){margin-left:.25rem;margin-right:.25rem}.button{text-transform:uppercase;font-weight:600;line-height:0;border:.125rem solid #767676;color:#767676;background-color:#fff;font-size:1.43rem;padding:calc(2rem - .187rem) 2.5rem}.button:hover{background-color:#767676;border-color:#767676;color:#fff;text-decoration:none}.button.big{font-size:1.75rem;padding:calc(2.5rem - .093rem) 2.5rem}.button.small{font-size:1rem;padding:.5rem calc(1rem + .2rem)}.button.tiny{font-family:"Source Sans Pro",sans-serif;padding:0 .5rem;font-size:1rem;text-transform:none;height:2rem}.button.tag{font-family:"Source Sans Pro",sans-serif;padding:0 1rem;font-size:.81rem;text-transform:none;min-height:1.81rem;height:auto;line-height:normal;white-space:normal;border-radius:18.75rem;border:.125rem solid #d8d8d8}.button.tag:hover{border-color:#767676}.button.tag--removable{font-family:"Source Sans Pro",sans-serif;padding:0 1rem;font-size:.81rem;text-transform:none;height:1.81rem;border-radius:18.75rem;border:.125rem solid #d8d8d8}.button.tag--removable:hover{color:#767676;background-color:#fff;border:.125rem solid #767676}.button.tag--removable:hover>.icon{color:#fff;background-color:#767676}.button.tag--removable:hover>.icon:first-child:last-child{margin-right:calc(-1rem - 1px)}.button.tag--removable .icon{height:1.56rem;width:1.9rem;line-height:1.56rem;font-size:1rem;background-color:#fff;color:#d8d8d8;border-top-right-radius:18.75rem;border-bottom-right-radius:18.75rem}.button.tag--removable .icon:first-child:last-child{margin-left:.3rem;margin-right:-1rem}.button.is-primary:hover{background-color:#ff6933}.button.is-success:hover{background-color:#00b850}.button.is-info:hover{background-color:#1066e7}.button.donate{background-color:#efbe00;border-color:#efbe00;color:#000}.button.donate:hover{background-color:#f5d400;border-color:#f5d400;color:#000;text-decoration:none}.button.is-text{height:auto !important;line-height:normal;text-align:left;text-decoration:none;white-space:normal}.button.is-text:hover,.button.is-text:active,.button.is-text:focus{border-color:rgba(0,0,0,0);box-shadow:none;background-color:rgba(0,0,0,0)}.select select,.textarea,.input{background-color:#fff;border-color:#d8d8d8;border-radius:4px;color:#333}.select select::-moz-placeholder,.textarea::-moz-placeholder,.input::-moz-placeholder{color:rgba(51,51,51,.3)}.select select::-webkit-input-placeholder,.textarea::-webkit-input-placeholder,.input::-webkit-input-placeholder{color:rgba(51,51,51,.3)}.select select:-moz-placeholder,.textarea:-moz-placeholder,.input:-moz-placeholder{color:rgba(51,51,51,.3)}.select select:-ms-input-placeholder,.textarea:-ms-input-placeholder,.input:-ms-input-placeholder{color:rgba(51,51,51,.3)}.select select:hover,.textarea:hover,.input:hover,.select select.is-hovered,.is-hovered.textarea,.is-hovered.input{border-color:#b0b0b0}.select select:focus,.textarea:focus,.input:focus,.select select.is-focused,.is-focused.textarea,.is-focused.input,.select select:active,.textarea:active,.input:active,.select select.is-active,.select .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select select.number,.select .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select select.is-active,.is-active.textarea,.table-of-progress .step :hover .textarea.number,.table-of-progress .step :hover .textarea.is-active,.is-active.input,.table-of-progress .step :hover .input.number,.table-of-progress .step :hover .input.is-active{border-color:#b0b0b0;box-shadow:0 0 0 .125em none}.select select[disabled],[disabled].textarea,[disabled].input,fieldset[disabled] .select select,.select fieldset[disabled] select,fieldset[disabled] .textarea,fieldset[disabled] .input{background-color:#f5f5f5;border-color:#b0b0b0;box-shadow:none;color:#b0b0b0}.select select[disabled]::-moz-placeholder,[disabled].textarea::-moz-placeholder,[disabled].input::-moz-placeholder,fieldset[disabled] .select select::-moz-placeholder,.select fieldset[disabled] select::-moz-placeholder,fieldset[disabled] .textarea::-moz-placeholder,fieldset[disabled] .input::-moz-placeholder{color:rgba(176,176,176,.3)}.select select[disabled]::-webkit-input-placeholder,[disabled].textarea::-webkit-input-placeholder,[disabled].input::-webkit-input-placeholder,fieldset[disabled] .select select::-webkit-input-placeholder,.select fieldset[disabled] select::-webkit-input-placeholder,fieldset[disabled] .textarea::-webkit-input-placeholder,fieldset[disabled] .input::-webkit-input-placeholder{color:rgba(176,176,176,.3)}.select select[disabled]:-moz-placeholder,[disabled].textarea:-moz-placeholder,[disabled].input:-moz-placeholder,fieldset[disabled] .select select:-moz-placeholder,.select fieldset[disabled] select:-moz-placeholder,fieldset[disabled] .textarea:-moz-placeholder,fieldset[disabled] .input:-moz-placeholder{color:rgba(176,176,176,.3)}.select select[disabled]:-ms-input-placeholder,[disabled].textarea:-ms-input-placeholder,[disabled].input:-ms-input-placeholder,fieldset[disabled] .select select:-ms-input-placeholder,.select fieldset[disabled] select:-ms-input-placeholder,fieldset[disabled] .textarea:-ms-input-placeholder,fieldset[disabled] .input:-ms-input-placeholder{color:rgba(176,176,176,.3)}.textarea,.input{box-shadow:none;max-width:100%;width:100%}[readonly].textarea,[readonly].input{box-shadow:none}.is-white.textarea,.is-white.input{border-color:#fff}.is-white.textarea:focus,.is-white.input:focus,.is-white.is-focused.textarea,.is-white.is-focused.input,.is-white.textarea:active,.is-white.input:active,.is-white.is-active.textarea,.table-of-progress .step :hover .is-white.textarea.number,.table-of-progress .step :hover .is-white.textarea.is-active,.is-white.is-active.input,.table-of-progress .step :hover .is-white.input.number,.table-of-progress .step :hover .is-white.input.is-active{box-shadow:0 0 0 .125em rgba(255,255,255,.25)}.is-black.textarea,.is-black.input{border-color:#000}.is-black.textarea:focus,.is-black.input:focus,.is-black.is-focused.textarea,.is-black.is-focused.input,.is-black.textarea:active,.is-black.input:active,.is-black.is-active.textarea,.table-of-progress .step :hover .is-black.textarea.number,.table-of-progress .step :hover .is-black.textarea.is-active,.is-black.is-active.input,.table-of-progress .step :hover .is-black.input.number,.table-of-progress .step :hover .is-black.input.is-active{box-shadow:0 0 0 .125em rgba(0,0,0,.25)}.is-light.textarea,.is-light.input{border-color:#f5f5f5}.is-light.textarea:focus,.is-light.input:focus,.is-light.is-focused.textarea,.is-light.is-focused.input,.is-light.textarea:active,.is-light.input:active,.is-light.is-active.textarea,.table-of-progress .step :hover .is-light.textarea.number,.table-of-progress .step :hover .is-light.textarea.is-active,.is-light.is-active.input,.table-of-progress .step :hover .is-light.input.number,.table-of-progress .step :hover .is-light.input.is-active{box-shadow:0 0 0 .125em rgba(245,245,245,.25)}.is-dark.textarea,.is-dark.input{border-color:#363636}.is-dark.textarea:focus,.is-dark.input:focus,.is-dark.is-focused.textarea,.is-dark.is-focused.input,.is-dark.textarea:active,.is-dark.input:active,.is-dark.is-active.textarea,.table-of-progress .step :hover .is-dark.textarea.number,.table-of-progress .step :hover .is-dark.textarea.is-active,.is-dark.is-active.input,.table-of-progress .step :hover .is-dark.input.number,.table-of-progress .step :hover .is-dark.input.is-active{box-shadow:0 0 0 .125em rgba(54,54,54,.25)}.is-primary.textarea,.is-primary.input{border-color:#e23600}.is-primary.textarea:focus,.is-primary.input:focus,.is-primary.is-focused.textarea,.is-primary.is-focused.input,.is-primary.textarea:active,.is-primary.input:active,.is-primary.is-active.textarea,.table-of-progress .step :hover .is-primary.textarea.number,.table-of-progress .step :hover .is-primary.textarea.is-active,.is-primary.is-active.input,.table-of-progress .step :hover .is-primary.input.number,.table-of-progress .step :hover .is-primary.input.is-active{box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.is-link.textarea,.is-link.input{border-color:#e23600}.is-link.textarea:focus,.is-link.input:focus,.is-link.is-focused.textarea,.is-link.is-focused.input,.is-link.textarea:active,.is-link.input:active,.is-link.is-active.textarea,.table-of-progress .step :hover .is-link.textarea.number,.table-of-progress .step :hover .is-link.textarea.is-active,.is-link.is-active.input,.table-of-progress .step :hover .is-link.input.number,.table-of-progress .step :hover .is-link.input.is-active{box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.is-info.textarea,.is-info.input{border-color:#1950b8}.is-info.textarea:focus,.is-info.input:focus,.is-info.is-focused.textarea,.is-info.is-focused.input,.is-info.textarea:active,.is-info.input:active,.is-info.is-active.textarea,.table-of-progress .step :hover .is-info.textarea.number,.table-of-progress .step :hover .is-info.textarea.is-active,.is-info.is-active.input,.table-of-progress .step :hover .is-info.input.number,.table-of-progress .step :hover .is-info.input.is-active{box-shadow:0 0 0 .125em rgba(25,80,184,.25)}.is-success.textarea,.is-success.input{border-color:#008300}.is-success.textarea:focus,.is-success.input:focus,.is-success.is-focused.textarea,.is-success.is-focused.input,.is-success.textarea:active,.is-success.input:active,.is-success.is-active.textarea,.table-of-progress .step :hover .is-success.textarea.number,.table-of-progress .step :hover .is-success.textarea.is-active,.is-success.is-active.input,.table-of-progress .step :hover .is-success.input.number,.table-of-progress .step :hover .is-success.input.is-active{box-shadow:0 0 0 .125em rgba(0,131,0,.25)}.is-warning.textarea,.is-warning.input{border-color:#f2ab20}.is-warning.textarea:focus,.is-warning.input:focus,.is-warning.is-focused.textarea,.is-warning.is-focused.input,.is-warning.textarea:active,.is-warning.input:active,.is-warning.is-active.textarea,.table-of-progress .step :hover .is-warning.textarea.number,.table-of-progress .step :hover .is-warning.textarea.is-active,.is-warning.is-active.input,.table-of-progress .step :hover .is-warning.input.number,.table-of-progress .step :hover .is-warning.input.is-active{box-shadow:0 0 0 .125em rgba(242,171,32,.25)}.is-danger.textarea,.is-danger.input{border-color:#c83b1e}.is-danger.textarea:focus,.is-danger.input:focus,.is-danger.is-focused.textarea,.is-danger.is-focused.input,.is-danger.textarea:active,.is-danger.input:active,.is-danger.is-active.textarea,.table-of-progress .step :hover .is-danger.textarea.number,.table-of-progress .step :hover .is-danger.textarea.is-active,.is-danger.is-active.input,.table-of-progress .step :hover .is-danger.input.number,.table-of-progress .step :hover .is-danger.input.is-active{box-shadow:0 0 0 .125em rgba(200,59,30,.25)}.is-small.textarea,.is-small.input{border-radius:2px;font-size:.8rem}.is-medium.textarea,.is-medium.input{font-size:1.12rem}.is-large.textarea,.is-large.input{font-size:1.43rem}.is-fullwidth.textarea,.is-fullwidth.input{display:block;width:100%}.is-inline.textarea,.is-inline.input{display:inline;width:auto}.input.is-rounded,.image .input.profile{border-radius:290486px;padding-left:calc(calc(0.75em - 1px) + .375em);padding-right:calc(calc(0.75em - 1px) + .375em)}.input.is-static{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0);box-shadow:none;padding-left:0;padding-right:0}.textarea{display:block;max-width:100%;min-width:100%;padding:calc(.75em - 1px);resize:vertical}.textarea:not([rows]){max-height:40em;min-height:8em}.textarea[rows]{height:initial}.textarea.has-fixed-size{resize:none}.radio,.checkbox{cursor:pointer;display:inline-block;line-height:1.25;position:relative}.radio input,.checkbox input{cursor:pointer}.radio:hover,.checkbox:hover{color:#363636}[disabled].radio,[disabled].checkbox,fieldset[disabled] .radio,fieldset[disabled] .checkbox,.radio input[disabled],.checkbox input[disabled]{color:#b0b0b0;cursor:not-allowed}.radio+.radio{margin-left:.5em}.select{display:inline-block;max-width:100%;position:relative;vertical-align:top}.select:not(.is-multiple){height:2.5em}.select:not(.is-multiple):not(.is-loading)::after{border-color:#e23600;right:1.125em;z-index:4}.select.is-rounded select,.image .select.profile select{border-radius:290486px;padding-left:1em}.select select{cursor:pointer;display:block;font-size:1em;max-width:100%;outline:none}.select select::-ms-expand{display:none}.select select[disabled]:hover,fieldset[disabled] .select select:hover{border-color:#b0b0b0}.select select:not([multiple]){padding-right:2.5em}.select select[multiple]{height:auto;padding:0}.select select[multiple] option{padding:.5em 1em}.select:not(.is-multiple):not(.is-loading):hover::after{border-color:#363636}.select.is-white:not(:hover)::after{border-color:#fff}.select.is-white select{border-color:#fff}.select.is-white select:hover,.select.is-white select.is-hovered{border-color:#f2f2f2}.select.is-white select:focus,.select.is-white select.is-focused,.select.is-white select:active,.select.is-white select.is-active,.select.is-white .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-white select.number,.select.is-white .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-white select.is-active{box-shadow:0 0 0 .125em rgba(255,255,255,.25)}.select.is-black:not(:hover)::after{border-color:#000}.select.is-black select{border-color:#000}.select.is-black select:hover,.select.is-black select.is-hovered{border-color:#000}.select.is-black select:focus,.select.is-black select.is-focused,.select.is-black select:active,.select.is-black select.is-active,.select.is-black .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-black select.number,.select.is-black .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-black select.is-active{box-shadow:0 0 0 .125em rgba(0,0,0,.25)}.select.is-light:not(:hover)::after{border-color:#f5f5f5}.select.is-light select{border-color:#f5f5f5}.select.is-light select:hover,.select.is-light select.is-hovered{border-color:#e8e8e8}.select.is-light select:focus,.select.is-light select.is-focused,.select.is-light select:active,.select.is-light select.is-active,.select.is-light .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-light select.number,.select.is-light .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-light select.is-active{box-shadow:0 0 0 .125em rgba(245,245,245,.25)}.select.is-dark:not(:hover)::after{border-color:#363636}.select.is-dark select{border-color:#363636}.select.is-dark select:hover,.select.is-dark select.is-hovered{border-color:#292929}.select.is-dark select:focus,.select.is-dark select.is-focused,.select.is-dark select:active,.select.is-dark select.is-active,.select.is-dark .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-dark select.number,.select.is-dark .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-dark select.is-active{box-shadow:0 0 0 .125em rgba(54,54,54,.25)}.select.is-primary:not(:hover)::after{border-color:#e23600}.select.is-primary select{border-color:#e23600}.select.is-primary select:hover,.select.is-primary select.is-hovered{border-color:#c93000}.select.is-primary select:focus,.select.is-primary select.is-focused,.select.is-primary select:active,.select.is-primary select.is-active,.select.is-primary .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-primary select.number,.select.is-primary .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-primary select.is-active{box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.select.is-link:not(:hover)::after{border-color:#e23600}.select.is-link select{border-color:#e23600}.select.is-link select:hover,.select.is-link select.is-hovered{border-color:#c93000}.select.is-link select:focus,.select.is-link select.is-focused,.select.is-link select:active,.select.is-link select.is-active,.select.is-link .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-link select.number,.select.is-link .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-link select.is-active{box-shadow:0 0 0 .125em rgba(226,54,0,.25)}.select.is-info:not(:hover)::after{border-color:#1950b8}.select.is-info select{border-color:#1950b8}.select.is-info select:hover,.select.is-info select.is-hovered{border-color:#1646a2}.select.is-info select:focus,.select.is-info select.is-focused,.select.is-info select:active,.select.is-info select.is-active,.select.is-info .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-info select.number,.select.is-info .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-info select.is-active{box-shadow:0 0 0 .125em rgba(25,80,184,.25)}.select.is-success:not(:hover)::after{border-color:#008300}.select.is-success select{border-color:#008300}.select.is-success select:hover,.select.is-success select.is-hovered{border-color:#006a00}.select.is-success select:focus,.select.is-success select.is-focused,.select.is-success select:active,.select.is-success select.is-active,.select.is-success .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-success select.number,.select.is-success .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-success select.is-active{box-shadow:0 0 0 .125em rgba(0,131,0,.25)}.select.is-warning:not(:hover)::after{border-color:#f2ab20}.select.is-warning select{border-color:#f2ab20}.select.is-warning select:hover,.select.is-warning select.is-hovered{border-color:#eba00e}.select.is-warning select:focus,.select.is-warning select.is-focused,.select.is-warning select:active,.select.is-warning select.is-active,.select.is-warning .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-warning select.number,.select.is-warning .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-warning select.is-active{box-shadow:0 0 0 .125em rgba(242,171,32,.25)}.select.is-danger:not(:hover)::after{border-color:#c83b1e}.select.is-danger select{border-color:#c83b1e}.select.is-danger select:hover,.select.is-danger select.is-hovered{border-color:#b2341b}.select.is-danger select:focus,.select.is-danger select.is-focused,.select.is-danger select:active,.select.is-danger select.is-active,.select.is-danger .table-of-progress .step :hover select.number,.table-of-progress .step :hover .select.is-danger select.number,.select.is-danger .table-of-progress .step :hover select.is-active,.table-of-progress .step :hover .select.is-danger select.is-active{box-shadow:0 0 0 .125em rgba(200,59,30,.25)}.select.is-small{border-radius:2px;font-size:.8rem}.select.is-medium{font-size:1.12rem}.select.is-large{font-size:1.43rem}.select.is-disabled::after{border-color:#b0b0b0}.select.is-fullwidth{width:100%}.select.is-fullwidth select{width:100%}.select.is-loading::after{margin-top:0;position:absolute;right:.625em;top:.625em;transform:none}.select.is-loading.is-small:after{font-size:.8rem}.select.is-loading.is-medium:after{font-size:1.12rem}.select.is-loading.is-large:after{font-size:1.43rem}.file{align-items:stretch;display:flex;justify-content:flex-start;position:relative}.file.is-white .file-cta{background-color:#fff;border-color:rgba(0,0,0,0);color:#000}.file.is-white:hover .file-cta,.file.is-white.is-hovered .file-cta{background-color:#f9f9f9;border-color:rgba(0,0,0,0);color:#000}.file.is-white:focus .file-cta,.file.is-white.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(255,255,255,.25);color:#000}.file.is-white:active .file-cta,.file.is-white.is-active .file-cta,.table-of-progress .step :hover .file.is-white.number .file-cta{background-color:#f2f2f2;border-color:rgba(0,0,0,0);color:#000}.file.is-black .file-cta{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.file.is-black:hover .file-cta,.file.is-black.is-hovered .file-cta{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.file.is-black:focus .file-cta,.file.is-black.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(0,0,0,.25);color:#fff}.file.is-black:active .file-cta,.file.is-black.is-active .file-cta,.table-of-progress .step :hover .file.is-black.number .file-cta{background-color:#000;border-color:rgba(0,0,0,0);color:#fff}.file.is-light .file-cta{background-color:#f5f5f5;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.file.is-light:hover .file-cta,.file.is-light.is-hovered .file-cta{background-color:#eee;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.file.is-light:focus .file-cta,.file.is-light.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(245,245,245,.25);color:rgba(0,0,0,.7)}.file.is-light:active .file-cta,.file.is-light.is-active .file-cta,.table-of-progress .step :hover .file.is-light.number .file-cta{background-color:#e8e8e8;border-color:rgba(0,0,0,0);color:rgba(0,0,0,.7)}.file.is-dark .file-cta{background-color:#363636;border-color:rgba(0,0,0,0);color:#fff}.file.is-dark:hover .file-cta,.file.is-dark.is-hovered .file-cta{background-color:#2f2f2f;border-color:rgba(0,0,0,0);color:#fff}.file.is-dark:focus .file-cta,.file.is-dark.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(54,54,54,.25);color:#fff}.file.is-dark:active .file-cta,.file.is-dark.is-active .file-cta,.table-of-progress .step :hover .file.is-dark.number .file-cta{background-color:#292929;border-color:rgba(0,0,0,0);color:#fff}.file.is-primary .file-cta{background-color:#e23600;border-color:rgba(0,0,0,0);color:#fff}.file.is-primary:hover .file-cta,.file.is-primary.is-hovered .file-cta{background-color:#d53300;border-color:rgba(0,0,0,0);color:#fff}.file.is-primary:focus .file-cta,.file.is-primary.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(226,54,0,.25);color:#fff}.file.is-primary:active .file-cta,.file.is-primary.is-active .file-cta,.table-of-progress .step :hover .file.is-primary.number .file-cta{background-color:#c93000;border-color:rgba(0,0,0,0);color:#fff}.file.is-link .file-cta{background-color:#e23600;border-color:rgba(0,0,0,0);color:#fff}.file.is-link:hover .file-cta,.file.is-link.is-hovered .file-cta{background-color:#d53300;border-color:rgba(0,0,0,0);color:#fff}.file.is-link:focus .file-cta,.file.is-link.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(226,54,0,.25);color:#fff}.file.is-link:active .file-cta,.file.is-link.is-active .file-cta,.table-of-progress .step :hover .file.is-link.number .file-cta{background-color:#c93000;border-color:rgba(0,0,0,0);color:#fff}.file.is-info .file-cta{background-color:#1950b8;border-color:rgba(0,0,0,0);color:#fff}.file.is-info:hover .file-cta,.file.is-info.is-hovered .file-cta{background-color:#174bad;border-color:rgba(0,0,0,0);color:#fff}.file.is-info:focus .file-cta,.file.is-info.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(25,80,184,.25);color:#fff}.file.is-info:active .file-cta,.file.is-info.is-active .file-cta,.table-of-progress .step :hover .file.is-info.number .file-cta{background-color:#1646a2;border-color:rgba(0,0,0,0);color:#fff}.file.is-success .file-cta{background-color:#008300;border-color:rgba(0,0,0,0);color:#fff}.file.is-success:hover .file-cta,.file.is-success.is-hovered .file-cta{background-color:#007600;border-color:rgba(0,0,0,0);color:#fff}.file.is-success:focus .file-cta,.file.is-success.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(0,131,0,.25);color:#fff}.file.is-success:active .file-cta,.file.is-success.is-active .file-cta,.table-of-progress .step :hover .file.is-success.number .file-cta{background-color:#006a00;border-color:rgba(0,0,0,0);color:#fff}.file.is-warning .file-cta{background-color:#f2ab20;border-color:rgba(0,0,0,0);color:#fff}.file.is-warning:hover .file-cta,.file.is-warning.is-hovered .file-cta{background-color:#f1a614;border-color:rgba(0,0,0,0);color:#fff}.file.is-warning:focus .file-cta,.file.is-warning.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(242,171,32,.25);color:#fff}.file.is-warning:active .file-cta,.file.is-warning.is-active .file-cta,.table-of-progress .step :hover .file.is-warning.number .file-cta{background-color:#eba00e;border-color:rgba(0,0,0,0);color:#fff}.file.is-danger .file-cta{background-color:#c83b1e;border-color:rgba(0,0,0,0);color:#fff}.file.is-danger:hover .file-cta,.file.is-danger.is-hovered .file-cta{background-color:#bd381c;border-color:rgba(0,0,0,0);color:#fff}.file.is-danger:focus .file-cta,.file.is-danger.is-focused .file-cta{border-color:rgba(0,0,0,0);box-shadow:0 0 .5em rgba(200,59,30,.25);color:#fff}.file.is-danger:active .file-cta,.file.is-danger.is-active .file-cta,.table-of-progress .step :hover .file.is-danger.number .file-cta{background-color:#b2341b;border-color:rgba(0,0,0,0);color:#fff}.file.is-small{font-size:.8rem}.file.is-medium{font-size:1.12rem}.file.is-medium .file-icon .fa{font-size:21px}.file.is-large{font-size:1.43rem}.file.is-large .file-icon .fa{font-size:28px}.file.has-name .file-cta{border-bottom-right-radius:0;border-top-right-radius:0}.file.has-name .file-name{border-bottom-left-radius:0;border-top-left-radius:0}.file.has-name.is-empty .file-cta{border-radius:4px}.file.has-name.is-empty .file-name{display:none}.file.is-boxed .file-label{flex-direction:column}.file.is-boxed .file-cta{flex-direction:column;height:auto;padding:1em 3em}.file.is-boxed .file-name{border-width:0 1px 1px}.file.is-boxed .file-icon{height:1.5em;width:1.5em}.file.is-boxed .file-icon .fa{font-size:21px}.file.is-boxed.is-small .file-icon .fa{font-size:14px}.file.is-boxed.is-medium .file-icon .fa{font-size:28px}.file.is-boxed.is-large .file-icon .fa{font-size:35px}.file.is-boxed.has-name .file-cta{border-radius:4px 4px 0 0}.file.is-boxed.has-name .file-name{border-radius:0 0 4px 4px;border-width:0 1px 1px}.file.is-centered{justify-content:center}.file.is-fullwidth .file-label{width:100%}.file.is-fullwidth .file-name{flex-grow:1;max-width:none}.file.is-right{justify-content:flex-end}.file.is-right .file-cta{border-radius:0 4px 4px 0}.file.is-right .file-name{border-radius:4px 0 0 4px;border-width:1px 0 1px 1px;order:-1}.file-label{align-items:stretch;display:flex;cursor:pointer;justify-content:flex-start;overflow:hidden;position:relative}.file-label:hover .file-cta{background-color:#eee;color:#363636}.file-label:hover .file-name{border-color:#efefef}.file-label:active .file-cta{background-color:#e8e8e8;color:#363636}.file-label:active .file-name{border-color:#e8e8e8}.file-input{height:100%;left:0;opacity:0;outline:none;position:absolute;top:0;width:100%}.file-cta,.file-name{border-color:#f5f5f5;border-radius:4px;font-size:1em;padding-left:1em;padding-right:1em;white-space:nowrap}.file-cta{background-color:#f5f5f5;color:#767676}.file-name{border-color:#f5f5f5;border-style:solid;border-width:1px 1px 1px 0;display:block;max-width:16em;overflow:hidden;text-align:inherit;text-overflow:ellipsis}.file-icon{align-items:center;display:flex;height:1em;justify-content:center;margin-right:.5em;width:1em}.file-icon .fa{font-size:14px}.label{color:#363636;display:block;font-size:1rem;font-weight:700}.label:not(:last-child){margin-bottom:.5em}.label.is-small{font-size:.8rem}.label.is-medium{font-size:1.12rem}.label.is-large{font-size:1.43rem}.help{display:block;font-size:.8rem;margin-top:.25rem}.help.is-white{color:#fff}.help.is-black{color:#000}.help.is-light{color:#f5f5f5}.help.is-dark{color:#363636}.help.is-primary{color:#e23600}.help.is-link{color:#e23600}.help.is-info{color:#1950b8}.help.is-success{color:#008300}.help.is-warning{color:#f2ab20}.help.is-danger{color:#c83b1e}.field:not(:last-child){margin-bottom:.75rem}.field.has-addons{display:flex;justify-content:flex-start}.field.has-addons .control:not(:last-child){margin-right:-1px}.field.has-addons .control:not(:first-child):not(:last-child) .button,.field.has-addons .control:not(:first-child):not(:last-child) .input,.field.has-addons .control:not(:first-child):not(:last-child) .select select{border-radius:0}.field.has-addons .control:first-child:not(:only-child) .button,.field.has-addons .control:first-child:not(:only-child) .input,.field.has-addons .control:first-child:not(:only-child) .select select{border-bottom-right-radius:0;border-top-right-radius:0}.field.has-addons .control:last-child:not(:only-child) .button,.field.has-addons .control:last-child:not(:only-child) .input,.field.has-addons .control:last-child:not(:only-child) .select select{border-bottom-left-radius:0;border-top-left-radius:0}.field.has-addons .control .button:not([disabled]):hover,.field.has-addons .control .button:not([disabled]).is-hovered,.field.has-addons .control .input:not([disabled]):hover,.field.has-addons .control .input:not([disabled]).is-hovered,.field.has-addons .control .select select:not([disabled]):hover,.field.has-addons .control .select select:not([disabled]).is-hovered{z-index:2}.field.has-addons .control .button:not([disabled]):focus,.field.has-addons .control .button:not([disabled]).is-focused,.field.has-addons .control .button:not([disabled]):active,.field.has-addons .control .button:not([disabled]).is-active,.field.has-addons .control .table-of-progress .step :hover .button.number:not([disabled]),.table-of-progress .step :hover .field.has-addons .control .button.number:not([disabled]),.field.has-addons .control .input:not([disabled]):focus,.field.has-addons .control .input:not([disabled]).is-focused,.field.has-addons .control .input:not([disabled]):active,.field.has-addons .control .input:not([disabled]).is-active,.field.has-addons .control .table-of-progress .step :hover .input.number:not([disabled]),.table-of-progress .step :hover .field.has-addons .control .input.number:not([disabled]),.field.has-addons .control .select select:not([disabled]):focus,.field.has-addons .control .select select:not([disabled]).is-focused,.field.has-addons .control .select select:not([disabled]):active,.field.has-addons .control .select select:not([disabled]).is-active,.field.has-addons .control .select .table-of-progress .step :hover select.number:not([disabled]),.table-of-progress .step :hover .field.has-addons .control .select select.number:not([disabled]){z-index:3}.field.has-addons .control .button:not([disabled]):focus:hover,.field.has-addons .control .button:not([disabled]).is-focused:hover,.field.has-addons .control .button:not([disabled]):active:hover,.field.has-addons .control .button:not([disabled]).is-active:hover,.field.has-addons .control .table-of-progress .step :hover .button.number:not([disabled]):hover,.table-of-progress .step :hover .field.has-addons .control .button.number:not([disabled]):hover,.field.has-addons .control .input:not([disabled]):focus:hover,.field.has-addons .control .input:not([disabled]).is-focused:hover,.field.has-addons .control .input:not([disabled]):active:hover,.field.has-addons .control .input:not([disabled]).is-active:hover,.field.has-addons .control .table-of-progress .step :hover .input.number:not([disabled]):hover,.table-of-progress .step :hover .field.has-addons .control .input.number:not([disabled]):hover,.field.has-addons .control .select select:not([disabled]):focus:hover,.field.has-addons .control .select select:not([disabled]).is-focused:hover,.field.has-addons .control .select select:not([disabled]):active:hover,.field.has-addons .control .select select:not([disabled]).is-active:hover,.field.has-addons .control .select .table-of-progress .step :hover select.number:not([disabled]):hover,.table-of-progress .step :hover .field.has-addons .control .select select.number:not([disabled]):hover{z-index:4}.field.has-addons .control.is-expanded{flex-grow:1;flex-shrink:1}.field.has-addons.has-addons-centered{justify-content:center}.field.has-addons.has-addons-right{justify-content:flex-end}.field.has-addons.has-addons-fullwidth .control{flex-grow:1;flex-shrink:0}.field.is-grouped{display:flex;justify-content:flex-start}.field.is-grouped>.control{flex-shrink:0}.field.is-grouped>.control:not(:last-child){margin-bottom:0;margin-right:.75rem}.field.is-grouped>.control.is-expanded{flex-grow:1;flex-shrink:1}.field.is-grouped.is-grouped-centered{justify-content:center}.field.is-grouped.is-grouped-right{justify-content:flex-end}.field.is-grouped.is-grouped-multiline{flex-wrap:wrap}.field.is-grouped.is-grouped-multiline>.control:last-child,.field.is-grouped.is-grouped-multiline>.control:not(:last-child){margin-bottom:.75rem}.field.is-grouped.is-grouped-multiline:last-child{margin-bottom:-0.75rem}.field.is-grouped.is-grouped-multiline:not(:last-child){margin-bottom:0}@media screen and (min-width: 769px),print{.field.is-horizontal{display:flex}}.field-label .label{font-size:inherit}@media screen and (max-width: 768px){.field-label{margin-bottom:.5rem}}@media screen and (min-width: 769px),print{.field-label{flex-basis:0;flex-grow:1;flex-shrink:0;margin-right:1.5rem;text-align:right}.field-label.is-small{font-size:.8rem;padding-top:.375em}.field-label.is-normal{padding-top:.375em}.field-label.is-medium{font-size:1.12rem;padding-top:.375em}.field-label.is-large{font-size:1.43rem;padding-top:.375em}}.field-body .field .field{margin-bottom:0}@media screen and (min-width: 769px),print{.field-body{display:flex;flex-basis:0;flex-grow:5;flex-shrink:1}.field-body .field{margin-bottom:0}.field-body>.field{flex-shrink:1}.field-body>.field:not(.is-narrow){flex-grow:1}.field-body>.field:not(:last-child){margin-right:.75rem}}.control{box-sizing:border-box;clear:both;font-size:1rem;position:relative;text-align:inherit}.control.has-icons-left .input:focus~.icon,.control.has-icons-left .select:focus~.icon,.control.has-icons-right .input:focus~.icon,.control.has-icons-right .select:focus~.icon{color:#b0b0b0}.control.has-icons-left .input.is-small~.icon,.control.has-icons-left .select.is-small~.icon,.control.has-icons-right .input.is-small~.icon,.control.has-icons-right .select.is-small~.icon{font-size:.8rem}.control.has-icons-left .input.is-medium~.icon,.control.has-icons-left .select.is-medium~.icon,.control.has-icons-right .input.is-medium~.icon,.control.has-icons-right .select.is-medium~.icon{font-size:1.12rem}.control.has-icons-left .input.is-large~.icon,.control.has-icons-left .select.is-large~.icon,.control.has-icons-right .input.is-large~.icon,.control.has-icons-right .select.is-large~.icon{font-size:1.43rem}.control.has-icons-left .icon,.control.has-icons-right .icon{color:#d8d8d8;height:2.5em;pointer-events:none;position:absolute;top:0;width:2.5em;z-index:4}.control.has-icons-left .input,.control.has-icons-left .select select{padding-left:2.5em}.control.has-icons-left .icon.is-left{left:0}.control.has-icons-right .input,.control.has-icons-right .select select{padding-right:2.5em}.control.has-icons-right .icon.is-right{right:0}.control.is-loading::after{position:absolute !important;right:.625em;top:.625em;z-index:4}.control.is-loading.is-small:after{font-size:.8rem}.control.is-loading.is-medium:after{font-size:1.12rem}.control.is-loading.is-large:after{font-size:1.43rem}.input{font-family:"Source Sans Pro",sans-serif;font-weight:600;line-height:1.3;border-width:.125rem;box-sizing:border-box;height:2.5em;padding-left:.5rem}.input.is-medium{font-size:1.43rem;height:3.875rem;padding-left:1rem}.input.is-large{font-size:1.75rem;height:5.063rem;padding-left:1.5rem}.textarea{font-family:"Source Sans Pro",sans-serif;font-weight:600;line-height:1.3;border-width:.125rem;box-sizing:border-box;min-height:6.875em;resize:both}.select select{font-family:"Source Sans Pro",sans-serif;font-weight:600;line-height:1.3;border-width:.125rem}.select select option{font-weight:400}.select:not(.is-multiple):not(.is-loading)::after{background:linear-gradient(45deg, rgb(0, 0, 0) 50%, transparent 50%);border:none;border-radius:0}.control{box-sizing:border-box;clear:both;font-size:1rem;position:relative;text-align:left}.control.has-icons-left .icon,.control.has-icons-right .icon{align-items:center;display:inline-flex;justify-content:center}.control.has-icons-left .icon .icon,.control.has-icons-right .icon .icon{color:inherit;position:unset}.control.has-icons-left .input:focus~.icon,.control.has-icons-left .input:hover~.icon,.control.has-icons-left .select:focus~.icon,.control.has-icons-left .select:hover~.icon,.control.has-icons-right .input:focus~.icon,.control.has-icons-right .input:hover~.icon,.control.has-icons-right .select:focus~.icon,.control.has-icons-right .select:hover~.icon{color:#b0b0b0}.control.has-icons-left .input:disabled~.icon,.control.has-icons-left .select:disabled~.icon,.control.has-icons-right .input:disabled~.icon,.control.has-icons-right .select:disabled~.icon{color:rgba(176,176,176,.3)}.control.has-icons-left .input.is-small~.icon,.control.has-icons-left .select.is-small~.icon,.control.has-icons-right .input.is-small~.icon,.control.has-icons-right .select.is-small~.icon{font-size:.8rem;height:2.5em}.control.has-icons-left .input.is-medium~.icon,.control.has-icons-left .select.is-medium~.icon,.control.has-icons-right .input.is-medium~.icon,.control.has-icons-right .select.is-medium~.icon{font-size:1.43rem;height:3.875rem}.control.has-icons-left .input.is-large~.icon,.control.has-icons-left .select.is-large~.icon,.control.has-icons-right .input.is-large~.icon,.control.has-icons-right .select.is-large~.icon{font-size:1.75rem;height:5.063rem}.control.has-icons-left .icon,.control.has-icons-right .icon{color:#d8d8d8;pointer-events:none;position:absolute;top:0;z-index:4}.control.has-icons-left .icon.is-left{left:0}.control.has-icons-right .icon.is-right{right:0}.container{flex-grow:1;margin:0 auto;position:relative;width:auto}.container.is-fluid{max-width:none !important;padding-left:32px;padding-right:32px;width:100%}@media screen and (min-width: 1024px){.container{max-width:960px}}@media screen and (max-width: 1215px){.container.is-widescreen:not(.is-max-desktop){max-width:1152px}}@media screen and (max-width: 1311px){.container.is-fullhd:not(.is-max-desktop):not(.is-max-widescreen){max-width:1248px}}@media screen and (min-width: 1216px){.container:not(.is-max-desktop){max-width:1152px}}@media screen and (min-width: 1312px){.container:not(.is-max-desktop):not(.is-max-widescreen){max-width:1248px}}.column{display:block;flex-basis:0;flex-grow:1;flex-shrink:1;padding:.75rem}.columns.is-mobile>.column.is-narrow{flex:none}.columns.is-mobile>.column.is-full{flex:none;width:100%}.columns.is-mobile>.column.is-three-quarters{flex:none;width:75%}.columns.is-mobile>.column.is-two-thirds{flex:none;width:66.6666%}.columns.is-mobile>.column.is-half{flex:none;width:50%}.columns.is-mobile>.column.is-one-third{flex:none;width:33.3333%}.columns.is-mobile>.column.is-one-quarter{flex:none;width:25%}.columns.is-mobile>.column.is-one-fifth{flex:none;width:20%}.columns.is-mobile>.column.is-two-fifths{flex:none;width:40%}.columns.is-mobile>.column.is-three-fifths{flex:none;width:60%}.columns.is-mobile>.column.is-four-fifths{flex:none;width:80%}.columns.is-mobile>.column.is-offset-three-quarters{margin-left:75%}.columns.is-mobile>.column.is-offset-two-thirds{margin-left:66.6666%}.columns.is-mobile>.column.is-offset-half{margin-left:50%}.columns.is-mobile>.column.is-offset-one-third{margin-left:33.3333%}.columns.is-mobile>.column.is-offset-one-quarter{margin-left:25%}.columns.is-mobile>.column.is-offset-one-fifth{margin-left:20%}.columns.is-mobile>.column.is-offset-two-fifths{margin-left:40%}.columns.is-mobile>.column.is-offset-three-fifths{margin-left:60%}.columns.is-mobile>.column.is-offset-four-fifths{margin-left:80%}.columns.is-mobile>.column.is-0{flex:none;width:0%}.columns.is-mobile>.column.is-offset-0{margin-left:0%}.columns.is-mobile>.column.is-1{flex:none;width:8.3333333333%}.columns.is-mobile>.column.is-offset-1{margin-left:8.3333333333%}.columns.is-mobile>.column.is-2{flex:none;width:16.6666666667%}.columns.is-mobile>.column.is-offset-2{margin-left:16.6666666667%}.columns.is-mobile>.column.is-3{flex:none;width:25%}.columns.is-mobile>.column.is-offset-3{margin-left:25%}.columns.is-mobile>.column.is-4{flex:none;width:33.3333333333%}.columns.is-mobile>.column.is-offset-4{margin-left:33.3333333333%}.columns.is-mobile>.column.is-5{flex:none;width:41.6666666667%}.columns.is-mobile>.column.is-offset-5{margin-left:41.6666666667%}.columns.is-mobile>.column.is-6{flex:none;width:50%}.columns.is-mobile>.column.is-offset-6{margin-left:50%}.columns.is-mobile>.column.is-7{flex:none;width:58.3333333333%}.columns.is-mobile>.column.is-offset-7{margin-left:58.3333333333%}.columns.is-mobile>.column.is-8{flex:none;width:66.6666666667%}.columns.is-mobile>.column.is-offset-8{margin-left:66.6666666667%}.columns.is-mobile>.column.is-9{flex:none;width:75%}.columns.is-mobile>.column.is-offset-9{margin-left:75%}.columns.is-mobile>.column.is-10{flex:none;width:83.3333333333%}.columns.is-mobile>.column.is-offset-10{margin-left:83.3333333333%}.columns.is-mobile>.column.is-11{flex:none;width:91.6666666667%}.columns.is-mobile>.column.is-offset-11{margin-left:91.6666666667%}.columns.is-mobile>.column.is-12{flex:none;width:100%}.columns.is-mobile>.column.is-offset-12{margin-left:100%}@media screen and (max-width: 768px){.column.is-narrow-mobile{flex:none}.column.is-full-mobile{flex:none;width:100%}.column.is-three-quarters-mobile{flex:none;width:75%}.column.is-two-thirds-mobile{flex:none;width:66.6666%}.column.is-half-mobile{flex:none;width:50%}.column.is-one-third-mobile{flex:none;width:33.3333%}.column.is-one-quarter-mobile{flex:none;width:25%}.column.is-one-fifth-mobile{flex:none;width:20%}.column.is-two-fifths-mobile{flex:none;width:40%}.column.is-three-fifths-mobile{flex:none;width:60%}.column.is-four-fifths-mobile{flex:none;width:80%}.column.is-offset-three-quarters-mobile{margin-left:75%}.column.is-offset-two-thirds-mobile{margin-left:66.6666%}.column.is-offset-half-mobile{margin-left:50%}.column.is-offset-one-third-mobile{margin-left:33.3333%}.column.is-offset-one-quarter-mobile{margin-left:25%}.column.is-offset-one-fifth-mobile{margin-left:20%}.column.is-offset-two-fifths-mobile{margin-left:40%}.column.is-offset-three-fifths-mobile{margin-left:60%}.column.is-offset-four-fifths-mobile{margin-left:80%}.column.is-0-mobile{flex:none;width:0%}.column.is-offset-0-mobile{margin-left:0%}.column.is-1-mobile{flex:none;width:8.3333333333%}.column.is-offset-1-mobile{margin-left:8.3333333333%}.column.is-2-mobile{flex:none;width:16.6666666667%}.column.is-offset-2-mobile{margin-left:16.6666666667%}.column.is-3-mobile{flex:none;width:25%}.column.is-offset-3-mobile{margin-left:25%}.column.is-4-mobile{flex:none;width:33.3333333333%}.column.is-offset-4-mobile{margin-left:33.3333333333%}.column.is-5-mobile{flex:none;width:41.6666666667%}.column.is-offset-5-mobile{margin-left:41.6666666667%}.column.is-6-mobile{flex:none;width:50%}.column.is-offset-6-mobile{margin-left:50%}.column.is-7-mobile{flex:none;width:58.3333333333%}.column.is-offset-7-mobile{margin-left:58.3333333333%}.column.is-8-mobile{flex:none;width:66.6666666667%}.column.is-offset-8-mobile{margin-left:66.6666666667%}.column.is-9-mobile{flex:none;width:75%}.column.is-offset-9-mobile{margin-left:75%}.column.is-10-mobile{flex:none;width:83.3333333333%}.column.is-offset-10-mobile{margin-left:83.3333333333%}.column.is-11-mobile{flex:none;width:91.6666666667%}.column.is-offset-11-mobile{margin-left:91.6666666667%}.column.is-12-mobile{flex:none;width:100%}.column.is-offset-12-mobile{margin-left:100%}}@media screen and (min-width: 769px),print{.column.is-narrow,.column.is-narrow-tablet{flex:none}.column.is-full,.column.is-full-tablet{flex:none;width:100%}.column.is-three-quarters,.column.is-three-quarters-tablet{flex:none;width:75%}.column.is-two-thirds,.column.is-two-thirds-tablet{flex:none;width:66.6666%}.column.is-half,.column.is-half-tablet{flex:none;width:50%}.column.is-one-third,.column.is-one-third-tablet{flex:none;width:33.3333%}.column.is-one-quarter,.column.is-one-quarter-tablet{flex:none;width:25%}.column.is-one-fifth,.column.is-one-fifth-tablet{flex:none;width:20%}.column.is-two-fifths,.column.is-two-fifths-tablet{flex:none;width:40%}.column.is-three-fifths,.column.is-three-fifths-tablet{flex:none;width:60%}.column.is-four-fifths,.column.is-four-fifths-tablet{flex:none;width:80%}.column.is-offset-three-quarters,.column.is-offset-three-quarters-tablet{margin-left:75%}.column.is-offset-two-thirds,.column.is-offset-two-thirds-tablet{margin-left:66.6666%}.column.is-offset-half,.column.is-offset-half-tablet{margin-left:50%}.column.is-offset-one-third,.column.is-offset-one-third-tablet{margin-left:33.3333%}.column.is-offset-one-quarter,.column.is-offset-one-quarter-tablet{margin-left:25%}.column.is-offset-one-fifth,.column.is-offset-one-fifth-tablet{margin-left:20%}.column.is-offset-two-fifths,.column.is-offset-two-fifths-tablet{margin-left:40%}.column.is-offset-three-fifths,.column.is-offset-three-fifths-tablet{margin-left:60%}.column.is-offset-four-fifths,.column.is-offset-four-fifths-tablet{margin-left:80%}.column.is-0,.column.is-0-tablet{flex:none;width:0%}.column.is-offset-0,.column.is-offset-0-tablet{margin-left:0%}.column.is-1,.column.is-1-tablet{flex:none;width:8.3333333333%}.column.is-offset-1,.column.is-offset-1-tablet{margin-left:8.3333333333%}.column.is-2,.column.is-2-tablet{flex:none;width:16.6666666667%}.column.is-offset-2,.column.is-offset-2-tablet{margin-left:16.6666666667%}.column.is-3,.column.is-3-tablet{flex:none;width:25%}.column.is-offset-3,.column.is-offset-3-tablet{margin-left:25%}.column.is-4,.column.is-4-tablet{flex:none;width:33.3333333333%}.column.is-offset-4,.column.is-offset-4-tablet{margin-left:33.3333333333%}.column.is-5,.column.is-5-tablet{flex:none;width:41.6666666667%}.column.is-offset-5,.column.is-offset-5-tablet{margin-left:41.6666666667%}.column.is-6,.column.is-6-tablet{flex:none;width:50%}.column.is-offset-6,.column.is-offset-6-tablet{margin-left:50%}.column.is-7,.column.is-7-tablet{flex:none;width:58.3333333333%}.column.is-offset-7,.column.is-offset-7-tablet{margin-left:58.3333333333%}.column.is-8,.column.is-8-tablet{flex:none;width:66.6666666667%}.column.is-offset-8,.column.is-offset-8-tablet{margin-left:66.6666666667%}.column.is-9,.column.is-9-tablet{flex:none;width:75%}.column.is-offset-9,.column.is-offset-9-tablet{margin-left:75%}.column.is-10,.column.is-10-tablet{flex:none;width:83.3333333333%}.column.is-offset-10,.column.is-offset-10-tablet{margin-left:83.3333333333%}.column.is-11,.column.is-11-tablet{flex:none;width:91.6666666667%}.column.is-offset-11,.column.is-offset-11-tablet{margin-left:91.6666666667%}.column.is-12,.column.is-12-tablet{flex:none;width:100%}.column.is-offset-12,.column.is-offset-12-tablet{margin-left:100%}}@media screen and (max-width: 1023px){.column.is-narrow-touch{flex:none}.column.is-full-touch{flex:none;width:100%}.column.is-three-quarters-touch{flex:none;width:75%}.column.is-two-thirds-touch{flex:none;width:66.6666%}.column.is-half-touch{flex:none;width:50%}.column.is-one-third-touch{flex:none;width:33.3333%}.column.is-one-quarter-touch{flex:none;width:25%}.column.is-one-fifth-touch{flex:none;width:20%}.column.is-two-fifths-touch{flex:none;width:40%}.column.is-three-fifths-touch{flex:none;width:60%}.column.is-four-fifths-touch{flex:none;width:80%}.column.is-offset-three-quarters-touch{margin-left:75%}.column.is-offset-two-thirds-touch{margin-left:66.6666%}.column.is-offset-half-touch{margin-left:50%}.column.is-offset-one-third-touch{margin-left:33.3333%}.column.is-offset-one-quarter-touch{margin-left:25%}.column.is-offset-one-fifth-touch{margin-left:20%}.column.is-offset-two-fifths-touch{margin-left:40%}.column.is-offset-three-fifths-touch{margin-left:60%}.column.is-offset-four-fifths-touch{margin-left:80%}.column.is-0-touch{flex:none;width:0%}.column.is-offset-0-touch{margin-left:0%}.column.is-1-touch{flex:none;width:8.3333333333%}.column.is-offset-1-touch{margin-left:8.3333333333%}.column.is-2-touch{flex:none;width:16.6666666667%}.column.is-offset-2-touch{margin-left:16.6666666667%}.column.is-3-touch{flex:none;width:25%}.column.is-offset-3-touch{margin-left:25%}.column.is-4-touch{flex:none;width:33.3333333333%}.column.is-offset-4-touch{margin-left:33.3333333333%}.column.is-5-touch{flex:none;width:41.6666666667%}.column.is-offset-5-touch{margin-left:41.6666666667%}.column.is-6-touch{flex:none;width:50%}.column.is-offset-6-touch{margin-left:50%}.column.is-7-touch{flex:none;width:58.3333333333%}.column.is-offset-7-touch{margin-left:58.3333333333%}.column.is-8-touch{flex:none;width:66.6666666667%}.column.is-offset-8-touch{margin-left:66.6666666667%}.column.is-9-touch{flex:none;width:75%}.column.is-offset-9-touch{margin-left:75%}.column.is-10-touch{flex:none;width:83.3333333333%}.column.is-offset-10-touch{margin-left:83.3333333333%}.column.is-11-touch{flex:none;width:91.6666666667%}.column.is-offset-11-touch{margin-left:91.6666666667%}.column.is-12-touch{flex:none;width:100%}.column.is-offset-12-touch{margin-left:100%}}@media screen and (min-width: 1024px){.column.is-narrow-desktop{flex:none}.column.is-full-desktop{flex:none;width:100%}.column.is-three-quarters-desktop{flex:none;width:75%}.column.is-two-thirds-desktop{flex:none;width:66.6666%}.column.is-half-desktop{flex:none;width:50%}.column.is-one-third-desktop{flex:none;width:33.3333%}.column.is-one-quarter-desktop{flex:none;width:25%}.column.is-one-fifth-desktop{flex:none;width:20%}.column.is-two-fifths-desktop{flex:none;width:40%}.column.is-three-fifths-desktop{flex:none;width:60%}.column.is-four-fifths-desktop{flex:none;width:80%}.column.is-offset-three-quarters-desktop{margin-left:75%}.column.is-offset-two-thirds-desktop{margin-left:66.6666%}.column.is-offset-half-desktop{margin-left:50%}.column.is-offset-one-third-desktop{margin-left:33.3333%}.column.is-offset-one-quarter-desktop{margin-left:25%}.column.is-offset-one-fifth-desktop{margin-left:20%}.column.is-offset-two-fifths-desktop{margin-left:40%}.column.is-offset-three-fifths-desktop{margin-left:60%}.column.is-offset-four-fifths-desktop{margin-left:80%}.column.is-0-desktop{flex:none;width:0%}.column.is-offset-0-desktop{margin-left:0%}.column.is-1-desktop{flex:none;width:8.3333333333%}.column.is-offset-1-desktop{margin-left:8.3333333333%}.column.is-2-desktop{flex:none;width:16.6666666667%}.column.is-offset-2-desktop{margin-left:16.6666666667%}.column.is-3-desktop{flex:none;width:25%}.column.is-offset-3-desktop{margin-left:25%}.column.is-4-desktop{flex:none;width:33.3333333333%}.column.is-offset-4-desktop{margin-left:33.3333333333%}.column.is-5-desktop{flex:none;width:41.6666666667%}.column.is-offset-5-desktop{margin-left:41.6666666667%}.column.is-6-desktop{flex:none;width:50%}.column.is-offset-6-desktop{margin-left:50%}.column.is-7-desktop{flex:none;width:58.3333333333%}.column.is-offset-7-desktop{margin-left:58.3333333333%}.column.is-8-desktop{flex:none;width:66.6666666667%}.column.is-offset-8-desktop{margin-left:66.6666666667%}.column.is-9-desktop{flex:none;width:75%}.column.is-offset-9-desktop{margin-left:75%}.column.is-10-desktop{flex:none;width:83.3333333333%}.column.is-offset-10-desktop{margin-left:83.3333333333%}.column.is-11-desktop{flex:none;width:91.6666666667%}.column.is-offset-11-desktop{margin-left:91.6666666667%}.column.is-12-desktop{flex:none;width:100%}.column.is-offset-12-desktop{margin-left:100%}}@media screen and (min-width: 1216px){.column.is-narrow-widescreen{flex:none}.column.is-full-widescreen{flex:none;width:100%}.column.is-three-quarters-widescreen{flex:none;width:75%}.column.is-two-thirds-widescreen{flex:none;width:66.6666%}.column.is-half-widescreen{flex:none;width:50%}.column.is-one-third-widescreen{flex:none;width:33.3333%}.column.is-one-quarter-widescreen{flex:none;width:25%}.column.is-one-fifth-widescreen{flex:none;width:20%}.column.is-two-fifths-widescreen{flex:none;width:40%}.column.is-three-fifths-widescreen{flex:none;width:60%}.column.is-four-fifths-widescreen{flex:none;width:80%}.column.is-offset-three-quarters-widescreen{margin-left:75%}.column.is-offset-two-thirds-widescreen{margin-left:66.6666%}.column.is-offset-half-widescreen{margin-left:50%}.column.is-offset-one-third-widescreen{margin-left:33.3333%}.column.is-offset-one-quarter-widescreen{margin-left:25%}.column.is-offset-one-fifth-widescreen{margin-left:20%}.column.is-offset-two-fifths-widescreen{margin-left:40%}.column.is-offset-three-fifths-widescreen{margin-left:60%}.column.is-offset-four-fifths-widescreen{margin-left:80%}.column.is-0-widescreen{flex:none;width:0%}.column.is-offset-0-widescreen{margin-left:0%}.column.is-1-widescreen{flex:none;width:8.3333333333%}.column.is-offset-1-widescreen{margin-left:8.3333333333%}.column.is-2-widescreen{flex:none;width:16.6666666667%}.column.is-offset-2-widescreen{margin-left:16.6666666667%}.column.is-3-widescreen{flex:none;width:25%}.column.is-offset-3-widescreen{margin-left:25%}.column.is-4-widescreen{flex:none;width:33.3333333333%}.column.is-offset-4-widescreen{margin-left:33.3333333333%}.column.is-5-widescreen{flex:none;width:41.6666666667%}.column.is-offset-5-widescreen{margin-left:41.6666666667%}.column.is-6-widescreen{flex:none;width:50%}.column.is-offset-6-widescreen{margin-left:50%}.column.is-7-widescreen{flex:none;width:58.3333333333%}.column.is-offset-7-widescreen{margin-left:58.3333333333%}.column.is-8-widescreen{flex:none;width:66.6666666667%}.column.is-offset-8-widescreen{margin-left:66.6666666667%}.column.is-9-widescreen{flex:none;width:75%}.column.is-offset-9-widescreen{margin-left:75%}.column.is-10-widescreen{flex:none;width:83.3333333333%}.column.is-offset-10-widescreen{margin-left:83.3333333333%}.column.is-11-widescreen{flex:none;width:91.6666666667%}.column.is-offset-11-widescreen{margin-left:91.6666666667%}.column.is-12-widescreen{flex:none;width:100%}.column.is-offset-12-widescreen{margin-left:100%}}@media screen and (min-width: 1312px){.column.is-narrow-fullhd{flex:none}.column.is-full-fullhd{flex:none;width:100%}.column.is-three-quarters-fullhd{flex:none;width:75%}.column.is-two-thirds-fullhd{flex:none;width:66.6666%}.column.is-half-fullhd{flex:none;width:50%}.column.is-one-third-fullhd{flex:none;width:33.3333%}.column.is-one-quarter-fullhd{flex:none;width:25%}.column.is-one-fifth-fullhd{flex:none;width:20%}.column.is-two-fifths-fullhd{flex:none;width:40%}.column.is-three-fifths-fullhd{flex:none;width:60%}.column.is-four-fifths-fullhd{flex:none;width:80%}.column.is-offset-three-quarters-fullhd{margin-left:75%}.column.is-offset-two-thirds-fullhd{margin-left:66.6666%}.column.is-offset-half-fullhd{margin-left:50%}.column.is-offset-one-third-fullhd{margin-left:33.3333%}.column.is-offset-one-quarter-fullhd{margin-left:25%}.column.is-offset-one-fifth-fullhd{margin-left:20%}.column.is-offset-two-fifths-fullhd{margin-left:40%}.column.is-offset-three-fifths-fullhd{margin-left:60%}.column.is-offset-four-fifths-fullhd{margin-left:80%}.column.is-0-fullhd{flex:none;width:0%}.column.is-offset-0-fullhd{margin-left:0%}.column.is-1-fullhd{flex:none;width:8.3333333333%}.column.is-offset-1-fullhd{margin-left:8.3333333333%}.column.is-2-fullhd{flex:none;width:16.6666666667%}.column.is-offset-2-fullhd{margin-left:16.6666666667%}.column.is-3-fullhd{flex:none;width:25%}.column.is-offset-3-fullhd{margin-left:25%}.column.is-4-fullhd{flex:none;width:33.3333333333%}.column.is-offset-4-fullhd{margin-left:33.3333333333%}.column.is-5-fullhd{flex:none;width:41.6666666667%}.column.is-offset-5-fullhd{margin-left:41.6666666667%}.column.is-6-fullhd{flex:none;width:50%}.column.is-offset-6-fullhd{margin-left:50%}.column.is-7-fullhd{flex:none;width:58.3333333333%}.column.is-offset-7-fullhd{margin-left:58.3333333333%}.column.is-8-fullhd{flex:none;width:66.6666666667%}.column.is-offset-8-fullhd{margin-left:66.6666666667%}.column.is-9-fullhd{flex:none;width:75%}.column.is-offset-9-fullhd{margin-left:75%}.column.is-10-fullhd{flex:none;width:83.3333333333%}.column.is-offset-10-fullhd{margin-left:83.3333333333%}.column.is-11-fullhd{flex:none;width:91.6666666667%}.column.is-offset-11-fullhd{margin-left:91.6666666667%}.column.is-12-fullhd{flex:none;width:100%}.column.is-offset-12-fullhd{margin-left:100%}}.columns{margin-left:-0.75rem;margin-right:-0.75rem;margin-top:-0.75rem}.columns:last-child{margin-bottom:-0.75rem}.columns:not(:last-child){margin-bottom:calc(1.5rem - 0.75rem)}.columns.is-centered{justify-content:center}.columns.is-gapless{margin-left:0;margin-right:0;margin-top:0}.columns.is-gapless>.column{margin:0;padding:0 !important}.columns.is-gapless:not(:last-child){margin-bottom:1.5rem}.columns.is-gapless:last-child{margin-bottom:0}.columns.is-mobile{display:flex}.columns.is-multiline{flex-wrap:wrap}.columns.is-vcentered{align-items:center}@media screen and (min-width: 769px),print{.columns:not(.is-desktop){display:flex}}@media screen and (min-width: 1024px){.columns.is-desktop{display:flex}}.columns.is-variable{--columnGap: 0.75rem;margin-left:calc(-1*var(--columnGap));margin-right:calc(-1*var(--columnGap))}.columns.is-variable .column{padding-left:var(--columnGap);padding-right:var(--columnGap)}.columns.is-variable.is-0{--columnGap: 0rem}@media screen and (max-width: 768px){.columns.is-variable.is-0-mobile{--columnGap: 0rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-0-tablet{--columnGap: 0rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-0-tablet-only{--columnGap: 0rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-0-touch{--columnGap: 0rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-0-desktop{--columnGap: 0rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-0-desktop-only{--columnGap: 0rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-0-widescreen{--columnGap: 0rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-0-widescreen-only{--columnGap: 0rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-0-fullhd{--columnGap: 0rem}}.columns.is-variable.is-1{--columnGap: 0.25rem}@media screen and (max-width: 768px){.columns.is-variable.is-1-mobile{--columnGap: 0.25rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-1-tablet{--columnGap: 0.25rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-1-tablet-only{--columnGap: 0.25rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-1-touch{--columnGap: 0.25rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-1-desktop{--columnGap: 0.25rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-1-desktop-only{--columnGap: 0.25rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-1-widescreen{--columnGap: 0.25rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-1-widescreen-only{--columnGap: 0.25rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-1-fullhd{--columnGap: 0.25rem}}.columns.is-variable.is-2{--columnGap: 0.5rem}@media screen and (max-width: 768px){.columns.is-variable.is-2-mobile{--columnGap: 0.5rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-2-tablet{--columnGap: 0.5rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-2-tablet-only{--columnGap: 0.5rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-2-touch{--columnGap: 0.5rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-2-desktop{--columnGap: 0.5rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-2-desktop-only{--columnGap: 0.5rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-2-widescreen{--columnGap: 0.5rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-2-widescreen-only{--columnGap: 0.5rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-2-fullhd{--columnGap: 0.5rem}}.columns.is-variable.is-3{--columnGap: 0.75rem}@media screen and (max-width: 768px){.columns.is-variable.is-3-mobile{--columnGap: 0.75rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-3-tablet{--columnGap: 0.75rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-3-tablet-only{--columnGap: 0.75rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-3-touch{--columnGap: 0.75rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-3-desktop{--columnGap: 0.75rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-3-desktop-only{--columnGap: 0.75rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-3-widescreen{--columnGap: 0.75rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-3-widescreen-only{--columnGap: 0.75rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-3-fullhd{--columnGap: 0.75rem}}.columns.is-variable.is-4{--columnGap: 1rem}@media screen and (max-width: 768px){.columns.is-variable.is-4-mobile{--columnGap: 1rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-4-tablet{--columnGap: 1rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-4-tablet-only{--columnGap: 1rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-4-touch{--columnGap: 1rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-4-desktop{--columnGap: 1rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-4-desktop-only{--columnGap: 1rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-4-widescreen{--columnGap: 1rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-4-widescreen-only{--columnGap: 1rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-4-fullhd{--columnGap: 1rem}}.columns.is-variable.is-5{--columnGap: 1.25rem}@media screen and (max-width: 768px){.columns.is-variable.is-5-mobile{--columnGap: 1.25rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-5-tablet{--columnGap: 1.25rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-5-tablet-only{--columnGap: 1.25rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-5-touch{--columnGap: 1.25rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-5-desktop{--columnGap: 1.25rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-5-desktop-only{--columnGap: 1.25rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-5-widescreen{--columnGap: 1.25rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-5-widescreen-only{--columnGap: 1.25rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-5-fullhd{--columnGap: 1.25rem}}.columns.is-variable.is-6{--columnGap: 1.5rem}@media screen and (max-width: 768px){.columns.is-variable.is-6-mobile{--columnGap: 1.5rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-6-tablet{--columnGap: 1.5rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-6-tablet-only{--columnGap: 1.5rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-6-touch{--columnGap: 1.5rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-6-desktop{--columnGap: 1.5rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-6-desktop-only{--columnGap: 1.5rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-6-widescreen{--columnGap: 1.5rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-6-widescreen-only{--columnGap: 1.5rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-6-fullhd{--columnGap: 1.5rem}}.columns.is-variable.is-7{--columnGap: 1.75rem}@media screen and (max-width: 768px){.columns.is-variable.is-7-mobile{--columnGap: 1.75rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-7-tablet{--columnGap: 1.75rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-7-tablet-only{--columnGap: 1.75rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-7-touch{--columnGap: 1.75rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-7-desktop{--columnGap: 1.75rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-7-desktop-only{--columnGap: 1.75rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-7-widescreen{--columnGap: 1.75rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-7-widescreen-only{--columnGap: 1.75rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-7-fullhd{--columnGap: 1.75rem}}.columns.is-variable.is-8{--columnGap: 2rem}@media screen and (max-width: 768px){.columns.is-variable.is-8-mobile{--columnGap: 2rem}}@media screen and (min-width: 769px),print{.columns.is-variable.is-8-tablet{--columnGap: 2rem}}@media screen and (min-width: 769px)and (max-width: 1023px){.columns.is-variable.is-8-tablet-only{--columnGap: 2rem}}@media screen and (max-width: 1023px){.columns.is-variable.is-8-touch{--columnGap: 2rem}}@media screen and (min-width: 1024px){.columns.is-variable.is-8-desktop{--columnGap: 2rem}}@media screen and (min-width: 1024px)and (max-width: 1215px){.columns.is-variable.is-8-desktop-only{--columnGap: 2rem}}@media screen and (min-width: 1216px){.columns.is-variable.is-8-widescreen{--columnGap: 2rem}}@media screen and (min-width: 1216px)and (max-width: 1311px){.columns.is-variable.is-8-widescreen-only{--columnGap: 2rem}}@media screen and (min-width: 1312px){.columns.is-variable.is-8-fullhd{--columnGap: 2rem}}.tile{align-items:stretch;display:block;flex-basis:0;flex-grow:1;flex-shrink:1;min-height:min-content}.tile.is-ancestor{margin-left:-0.75rem;margin-right:-0.75rem;margin-top:-0.75rem}.tile.is-ancestor:last-child{margin-bottom:-0.75rem}.tile.is-ancestor:not(:last-child){margin-bottom:.75rem}.tile.is-child{margin:0 !important}.tile.is-parent{padding:.75rem}.tile.is-vertical{flex-direction:column}.tile.is-vertical>.tile.is-child:not(:last-child){margin-bottom:1.5rem !important}@media screen and (min-width: 769px),print{.tile:not(.is-child){display:flex}.tile.is-1{flex:none;width:8.3333333333%}.tile.is-2{flex:none;width:16.6666666667%}.tile.is-3{flex:none;width:25%}.tile.is-4{flex:none;width:33.3333333333%}.tile.is-5{flex:none;width:41.6666666667%}.tile.is-6{flex:none;width:50%}.tile.is-7{flex:none;width:58.3333333333%}.tile.is-8{flex:none;width:66.6666666667%}.tile.is-9{flex:none;width:75%}.tile.is-10{flex:none;width:83.3333333333%}.tile.is-11{flex:none;width:91.6666666667%}.tile.is-12{flex:none;width:100%}}.card{background-color:#fff;border-radius:.25rem;box-shadow:none;color:#767676;max-width:100%;overflow:hidden;position:relative}.card-header{background-color:rgba(0,0,0,0);align-items:stretch;box-shadow:none;display:flex}.card-header-title{align-items:center;color:#363636;display:flex;flex-grow:1;font-weight:700;padding:.75rem 1rem}.card-header-title.is-centered{justify-content:center}.card-header-icon{align-items:center;cursor:pointer;display:flex;justify-content:center;padding:.75rem 1rem}.card-image{display:block;position:relative}.card-content{background-color:rgba(0,0,0,0);padding:1.5rem}.card-footer{background-color:rgba(0,0,0,0);border-top:1px solid #ededed;align-items:stretch;display:flex}.card-footer-item{align-items:center;display:flex;flex-basis:0;flex-grow:1;flex-shrink:0;justify-content:center;padding:.75rem}.card-footer-item:not(:last-child){border-right:1px solid #ededed}.card .media:not(:last-child){margin-bottom:1.5rem}.card.entry-post{border:3px solid #d8d8d8}.card.entry-post.no-border{border:none}.card.entry-post .card-content{padding:1.5rem 2rem}.card.entry-post .card-content .card-title{text-transform:none;line-height:1.6rem}.card.entry-post .card-content .card-title a{color:#000}.card.entry-post .card-content .subtitle{display:block;margin-top:1rem;color:#b0b0b0;font-size:.9rem;font-weight:700;text-transform:uppercase;letter-spacing:.1rem}.card.entry-post .card-content .content{padding-top:1.5rem}.card.entry-post .card-content.with-button .content{padding:1.5rem 0}.card.entry-post .card-content .read-more{position:relative;margin-top:1.5rem;text-transform:uppercase;color:#b0b0b0;letter-spacing:2%}.card.entry-post .card-content .read-more .icon{padding-left:1rem}.card.entry-post .card-content .read-more:hover{text-decoration:none;color:#767676}.card.entry-post.horizontal{display:flex}.card.entry-post.horizontal .card-content{padding:2rem}.card.entry-post.horizontal .card-image .image{height:100%}.card.entry-post.horizontal .card-image .image img{object-fit:cover;height:100%}.card.entry-post.entry-video .card-image a .image:before{content:"";position:absolute;padding:1.5rem;top:0;left:0;width:5rem;height:5rem;background-color:#efbe00;color:#fff;font-family:"Vocabulary Icons",monospace !important;font-size:3rem;line-height:.7;text-align:center;z-index:10}.card.entry-post.entry-video.large>*{flex:0 0 auto}.card.entry-post.entry-video.large .card-image{width:70%}.card.entry-post.entry-video.large .card-image a .image:before{bottom:0;right:0;margin:auto}.card.entry-post.entry-video.large .card-image a .image img{width:100%}.card.entry-post.entry-video.large .card-content{width:30%}.card.entry-post.entry-video.large .card-content .card-title{text-transform:uppercase;line-height:3.7rem}.card.entry-post.entry-event .card-header{width:30%;justify-content:center;align-items:center}.card.entry-post.entry-event .card-header .card-date{padding:1.5rem;text-align:center}.card.entry-post.entry-event .card-header .card-date>*{display:block}.card.entry-post.entry-event .card-header .card-date .month{text-transform:uppercase;color:#767676}.card.entry-post.entry-event .card-header .card-date .day{font-size:4.4rem;font-weight:600;line-height:4rem}.card.entry-post.entry-event .card-header .card-date .year{color:#767676}.card.entry-post.entry-event .card-content .content{padding-bottom:1.5rem}.card.entry-post.entry-statistic .card-header{width:65%;padding:1.5rem;align-items:center}.card.entry-post.entry-statistic .card-header .card-statistic>*{display:block}.card.entry-post.entry-statistic .card-header .card-statistic .number,.card.entry-post.entry-statistic .card-header .card-statistic .table-of-progress .step .is-active,.table-of-progress .step .card.entry-post.entry-statistic .card-header .card-statistic .is-active{font-size:4.4rem;font-weight:600;line-height:4rem}.card.entry-post.entry-statistic .card-header .card-statistic .caption,.card.entry-post.entry-statistic .card-header .card-statistic .image .image-title,.image .card.entry-post.entry-statistic .card-header .card-statistic .image-title{font-size:1.4rem;font-weight:600;text-transform:uppercase}.card.entry-post.entry-statistic .card-content .content{padding-bottom:1rem;padding-top:0}.card.entry-post.entry-quote{padding:1.5rem}.card.entry-post.entry-quote .card-image{width:80%}.card.entry-post.entry-quote .card-image .image img{object-fit:none;height:auto;border:3px solid #d8d8d8}.card.entry-post.entry-quote .card-content{padding-top:0}.card.entry-post.entry-quote .card-content .quote{display:block;width:46px;height:32px;background-repeat:no-repeat;background-image:url("data:image/svg+xml,%3Csvg width='46' height='32' viewBox='0 0 46 32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M27.3836 26.8797C25.8676 24.1902 25 21.0676 25 17.737C25 11.3769 29.1325 2.81312 39.3401 0L41.196 5.31367C36.3588 7.02275 33.1774 10.4191 32.8559 12.5458C33.8727 12.1893 34.9648 11.9956 36.1017 11.9956C41.5684 11.9956 46 16.4737 46 21.9978C46 27.5219 41.5684 32 36.1017 32C32.3717 32 29.1235 29.9151 27.4362 26.8357L27.3836 26.8797Z' fill='%23D8D8D8'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M2.38359 26.8797C0.867634 24.1902 -1.90735e-06 21.0676 -1.90735e-06 17.737C-1.90735e-06 11.3769 4.13252 2.81312 14.3401 0L16.196 5.31367C11.3588 7.02275 8.17739 10.4191 7.85587 12.5458C8.87269 12.1893 9.96483 11.9956 11.1017 11.9956C16.5684 11.9956 21 16.4737 21 21.9978C21 27.5219 16.5684 32 11.1017 32C7.37168 32 4.12352 29.9151 2.43624 26.8357L2.38359 26.8797Z' fill='%23D8D8D8'/%3E%3C/svg%3E%0A")}.card.entry-post.entry-quote .card-content .content{font-size:1.4rem}.card.entry-post.entry-quote .card-content .content .quote-author{font-size:1rem;margin-top:1.5rem}.card.entry-post.entry-image .card-content .card-title{margin-bottom:1rem;text-transform:uppercase}.card.entry-post.entry-image .card-content .card-title a{color:#000}.card.entry-post.entry-image .card-content .card-title a:hover{color:#767676}.card.entry-post.entry-image .card-content .subtitle{color:#b0b0b0;font-weight:600;letter-spacing:.1rem}.card.entry-post.link a{display:block;padding:2rem;color:#000}.card.entry-post.link a.has-background-tomato{color:#fff}.card.entry-post.link a.has-background-tomato .card-content .card-title{color:#fff}.card.entry-post.link a.has-background-gold{color:#000}.card.entry-post.link a.has-background-forest-green{color:#fff}.card.entry-post.link a.has-background-forest-green .card-content .card-title{color:#fff}.card.entry-post.link a.has-background-dark-turquoise{color:#fff}.card.entry-post.link a.has-background-dark-turquoise .card-content .card-title{color:#fff}.card.entry-post.link a.has-background-dark-slate-blue{color:#fff}.card.entry-post.link a.has-background-dark-slate-blue .card-content .card-title{color:#fff}.card.entry-post.link a.has-background-brighter-dark-slate-blue{color:#fff}.card.entry-post.link a.has-background-brighter-dark-slate-blue .card-content .card-title{color:#fff}.card.entry-post.link a.has-background-dark-slate-gray{color:#fff}.card.entry-post.link a.has-background-dark-slate-gray .card-content .card-title{color:#fff}.card.entry-post.link a .card-content{display:block;position:relative}.card.entry-post.link a .card-content.has-bottom-link{padding:0 0 6rem 0}.card.entry-post.link a .card-content .card-title{text-transform:uppercase;line-height:2.5rem}.card.entry-post.link a .card-content .content{display:block;font-weight:600}.card.entry-post.link a .card-content .link-arrow{position:absolute;bottom:0;right:0;text-transform:uppercase}.card.entry-post.link a .card-content .link-arrow .icon{padding-left:1rem}.card.entry-post.link a:hover{text-decoration:none}.card.entry-post.link a:hover.has-background-tomato{background-color:#ff4e16 !important}.card.entry-post.link a:hover.has-background-gold{background-color:#ffd223 !important}.card.entry-post.link a:hover.has-background-forest-green{background-color:#00b600 !important}.card.entry-post.link a:hover.has-background-dark-turquoise{background-color:#18d3fa !important}.card.entry-post.link a:hover.has-background-dark-slate-blue{background-color:#4e73ba !important}.card.entry-post.link a:hover.has-background-brighter-dark-slate-blue{background-color:#3983f1 !important}.card.entry-post.link a:hover.has-background-dark-slate-gray{background-color:#4d4d4d !important}.card.blog-entry{background-color:rgba(0,0,0,0)}.card.blog-entry .blog-image{width:5rem;height:5rem}.table{background-color:#fff;color:#333}.table td,.table th{border:1px solid #d8d8d8;border-width:0 0 1px;padding:1rem;vertical-align:top}.table td.is-white,.table th.is-white{background-color:#fff;border-color:#fff;color:#000}.table td.is-black,.table th.is-black{background-color:#000;border-color:#000;color:#fff}.table td.is-light,.table th.is-light{background-color:#f5f5f5;border-color:#f5f5f5;color:rgba(0,0,0,.7)}.table td.is-dark,.table th.is-dark{background-color:#363636;border-color:#363636;color:#fff}.table td.is-primary,.table th.is-primary{background-color:#e23600;border-color:#e23600;color:#fff}.table td.is-link,.table th.is-link{background-color:#e23600;border-color:#e23600;color:#fff}.table td.is-info,.table th.is-info{background-color:#1950b8;border-color:#1950b8;color:#fff}.table td.is-success,.table th.is-success{background-color:#008300;border-color:#008300;color:#fff}.table td.is-warning,.table th.is-warning{background-color:#f2ab20;border-color:#f2ab20;color:#fff}.table td.is-danger,.table th.is-danger{background-color:#c83b1e;border-color:#c83b1e;color:#fff}.table td.is-narrow,.table th.is-narrow{white-space:nowrap;width:1%}.table td.is-selected,.table th.is-selected{background-color:#e23600;color:#fff}.table td.is-selected a,.table td.is-selected strong,.table th.is-selected a,.table th.is-selected strong{color:currentColor}.table td.is-vcentered,.table th.is-vcentered{vertical-align:middle}.table th{color:#363636}.table th:not([align]){text-align:inherit}.table tr.is-selected{background-color:#e23600;color:#fff}.table tr.is-selected a,.table tr.is-selected strong{color:currentColor}.table tr.is-selected td,.table tr.is-selected th{border-color:#fff;color:currentColor}.table thead{background-color:#d8d8d8}.table thead td,.table thead th{border-width:0 0 2px;color:#363636}.table tfoot{background-color:rgba(0,0,0,0)}.table tfoot td,.table tfoot th{border-width:2px 0 0;color:#363636}.table tbody{background-color:rgba(0,0,0,0)}.table tbody tr:last-child td,.table tbody tr:last-child th{border-bottom-width:0}.table.is-bordered td,.table.is-bordered th{border-width:1px}.table.is-bordered tr:last-child td,.table.is-bordered tr:last-child th{border-bottom-width:1px}.table.is-fullwidth{width:100%}.table.is-hoverable tbody tr:not(.is-selected):hover{background-color:#fafafa}.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover{background-color:#fafafa}.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even){background-color:#f5f5f5}.table.is-narrow td,.table.is-narrow th{padding:.25em .5em}.table.is-striped tbody tr:not(.is-selected):nth-child(even){background-color:#f5f5f5}.table-container{-webkit-overflow-scrolling:touch;overflow:auto;overflow-y:hidden;max-width:100%}.number-cell{text-align:right !important}.table{line-height:1.5}@media only screen and (max-width: 760px),(min-device-width: 769px)and (max-device-width: 1024px){.is-responsive table,.is-responsive thead,.is-responsive tbody,.is-responsive th,.is-responsive td,.is-responsive tr{display:block}.is-responsive thead tr{position:absolute;top:-9999px;left:-9999px}.is-responsive tr{margin-top:1rem}.is-responsive td{position:relative;text-align:left !important;padding-left:calc(45% + 1rem);background-color:#fff}.is-responsive td:nth-child(2n){background-color:#f5f5f5}.is-responsive td:first-child{border-top-left-radius:.25rem;border-top-right-radius:.25rem}.is-responsive td:last-child{border-bottom-left-radius:.25rem;border-bottom-right-radius:.25rem}.is-responsive td:before{position:absolute;top:0;left:0;font-size:1rem;font-weight:bold;line-height:1.5;height:100%;width:45%;padding:1rem;background-color:#d8d8d8;border-right:.0625rem solid #d8d8d8}.is-responsive td:nth-of-type(n):before{content:attr(data-label)}}.tabs{-webkit-overflow-scrolling:touch;align-items:stretch;display:flex;font-size:1rem;justify-content:space-between;overflow:hidden;overflow-x:auto;white-space:nowrap}.tabs a{align-items:center;border-bottom-color:#d8d8d8;border-bottom-style:solid;border-bottom-width:2px;color:#333;display:flex;justify-content:center;margin-bottom:-2px;padding:0 0 1rem 0;vertical-align:top}.tabs a:hover{border-bottom-color:#363636;color:#363636}.tabs li{display:block}.tabs li.is-active a,.tabs .table-of-progress .step :hover li.number a,.table-of-progress .step :hover .tabs li.number a,.tabs .table-of-progress .step :hover li.is-active a,.table-of-progress .step :hover .tabs li.is-active a{border-bottom-color:#333;color:#333}.tabs ul{align-items:center;border-bottom-color:#d8d8d8;border-bottom-style:solid;border-bottom-width:2px;display:flex;flex-grow:1;flex-shrink:0;justify-content:flex-start}.tabs ul.is-left{padding-right:.75em}.tabs ul.is-center{flex:none;justify-content:center;padding-left:.75em;padding-right:.75em}.tabs ul.is-right{justify-content:flex-end;padding-left:.75em}.tabs .icon:first-child{margin-right:.5em}.tabs .icon:last-child{margin-left:.5em}.tabs.is-centered ul{justify-content:center}.tabs.is-right ul{justify-content:flex-end}.tabs.is-boxed a{border:1px solid rgba(0,0,0,0);border-radius:0 0 0 0}.tabs.is-boxed a:hover{background-color:#fff;border-bottom-color:#fff}.tabs.is-boxed li.is-active a,.tabs.is-boxed .table-of-progress .step :hover li.number a,.table-of-progress .step :hover .tabs.is-boxed li.number a,.tabs.is-boxed .table-of-progress .step :hover li.is-active a,.table-of-progress .step :hover .tabs.is-boxed li.is-active a{background-color:#fff;border-color:#d8d8d8;border-bottom-color:rgba(0,0,0,0) !important}.tabs.is-fullwidth li{flex-grow:1;flex-shrink:0}.tabs.is-toggle a{border-color:#f5f5f5;border-style:solid;border-width:1px;margin-bottom:0;position:relative}.tabs.is-toggle a:hover{background-color:#f5f5f5;border-color:#d8d8d8;z-index:2}.tabs.is-toggle li+li{margin-left:-1px}.tabs.is-toggle li:first-child a{border-top-left-radius:4px;border-bottom-left-radius:4px}.tabs.is-toggle li:last-child a{border-top-right-radius:4px;border-bottom-right-radius:4px}.tabs.is-toggle li.is-active a,.tabs.is-toggle .table-of-progress .step :hover li.number a,.table-of-progress .step :hover .tabs.is-toggle li.number a,.tabs.is-toggle .table-of-progress .step :hover li.is-active a,.table-of-progress .step :hover .tabs.is-toggle li.is-active a{background-color:#e23600;border-color:#e23600;color:#fff;z-index:1}.tabs.is-toggle ul{border-bottom:none}.tabs.is-toggle.is-toggle-rounded li:first-child a{border-bottom-left-radius:290486px;border-top-left-radius:290486px;padding-left:1.25em}.tabs.is-toggle.is-toggle-rounded li:last-child a{border-bottom-right-radius:290486px;border-top-right-radius:290486px;padding-right:1.25em}.tabs.is-small{font-size:.8rem}.tabs.is-medium{font-size:1.12rem}.tabs.is-large{font-size:1.43rem}.tabs{font-family:"Source Sans Pro",sans-serif}.tabs a{font-size:1.25rem;font-weight:700;text-decoration:none;border-bottom:4px solid rgba(0,0,0,0);margin:0 1rem -2px 1rem}.tabs a:hover{border-bottom-color:#333}.tabs li:first-child a{margin-left:0}.tabs li:last-child a{margin-right:0}.tabs.is-boxed a{margin:0 0 -2px;border:2px solid #d8d8d8;border-right:0;background-color:#f5f5f5;font-size:1rem}.tabs.is-boxed li:last-child a{border-right:2px solid #d8d8d8}.tabs-content{margin-top:-1.5rem;padding-top:2rem}.tabs-content .tabs-panel{display:none}.tabs-content .tabs-panel.is-active,.tabs-content .table-of-progress .step :hover .tabs-panel.number,.table-of-progress .step :hover .tabs-content .tabs-panel.number,.tabs-content .table-of-progress .step :hover .tabs-panel.is-active,.table-of-progress .step :hover .tabs-content .tabs-panel.is-active{display:block}.tabs-content.is-boxed{border:2px solid #d8d8d8;border-top:0;background-color:#fff}.notification .notification-container{display:block;position:relative;width:100%;color:#000;border-radius:.25rem}.notification .notification-container .icon-container{position:absolute;display:flex;right:3rem;top:0;bottom:0;width:2.5rem;height:2.5rem;margin:auto;align-items:center;justify-content:center;border-radius:50%;border-width:2px;border-style:solid}.notification.warning .notification-container{padding:3rem 6rem 3rem 3rem;background-color:#faecbc}.notification.warning .notification-container .icon-container{color:#f2ab20;border-color:#f2ab20}.notification.warning .notification-container:hover .b-header,.notification.warning .notification-container:hover .table-of-progress .step-header,.table-of-progress .notification.warning .notification-container:hover .step-header{text-decoration:underline}@media screen and (max-width: 768px){.notification.warning .notification-container{padding:2rem}.notification.warning .notification-container .icon-container{display:none}}.notification.content .notification-container{display:flex;background-color:#fff;border:2px solid #d8d8d8}.notification.content .notification-container .content-image img{object-fit:cover;width:100%;height:100%;border-radius:.25rem 0 0 .25rem}.notification.content .notification-container .content-wrap{width:100%;padding:3rem 6rem 3rem 3rem}.notification.content .notification-container .content-wrap .icon-container{color:#b0b0b0;border-color:#b0b0b0}.notification.content .notification-container:hover{border:2px solid #b0b0b0;box-shadow:.5rem .5rem 0 rgba(0,0,0,.06)}@media screen and (max-width: 768px){.notification.content .notification-container .content-image{display:none}.notification.content .notification-container .content-wrap{padding:2rem}.notification.content .notification-container .content-wrap .icon-container{display:none}}.notification.is-compact .notification-container{padding-left:1.5rem}.notification.is-compact .notification-container p{font-weight:bold;line-height:1.5rem;color:#333}.menu{font-size:1rem}.menu.is-small{font-size:.8rem}.menu.is-medium{font-size:1.12rem}.menu.is-large{font-size:1.43rem}.menu-list{line-height:1.25}.menu-list a{border-radius:2px;color:#e23600;display:block;padding:.5rem 0}.menu-list a:hover{background-color:none;color:#363636}.menu-list a.is-active,.menu-list .table-of-progress .step :hover a.number,.table-of-progress .step :hover .menu-list a.number,.menu-list .table-of-progress .step :hover a.is-active,.table-of-progress .step :hover .menu-list a.is-active{background-color:none;color:#333}.menu-list li ul{border-left:none;margin:0;padding-left:0}.menu-label{color:#b0b0b0;font-size:.75em;letter-spacing:.1em;text-transform:uppercase}.menu-label:not(:first-child){margin-top:1em}.menu-label:not(:last-child){margin-bottom:1em}.sidebar-menu{font-weight:bold;line-height:1.5;background-color:#f5f5f5}.sidebar-menu .menu-list .link{text-decoration:none}.sidebar-menu .icon{font-size:.375rem}.sidebar-menu .divider{border-top:.1875rem solid #fff}.menu{font-size:1rem}.menu.is-small{font-size:.8rem}.menu.is-medium{font-size:1.12rem}.menu.is-large{font-size:1.43rem}.menu-list{line-height:1.25}.menu-list a{border-radius:2px;color:#e23600;display:block;padding:.5rem 0}.menu-list a:hover{background-color:none;color:#363636}.menu-list a.is-active,.menu-list .table-of-progress .step :hover a.number,.table-of-progress .step :hover .menu-list a.number,.menu-list .table-of-progress .step :hover a.is-active,.table-of-progress .step :hover .menu-list a.is-active{background-color:none;color:#333}.menu-list li ul{border-left:none;margin:0;padding-left:0}.menu-label{color:#b0b0b0;font-size:.75em;letter-spacing:.1em;text-transform:uppercase}.menu-label:not(:first-child){margin-top:1em}.menu-label:not(:last-child){margin-bottom:1em}.table-of-contents{font-weight:bold;line-height:1.5;border:.125rem solid #f5f5f5;box-sizing:border-box;background-color:#fff}.table-of-contents .menu-list .link{text-decoration:none}.table-of-contents .icon{font-size:.375rem}.table-of-progress .step-header{line-height:1.6875}.table-of-progress .step .link{text-decoration:none;line-height:1.25;font-weight:bold}.table-of-progress .step .number,.table-of-progress .step .is-active,.table-of-progress .step :hover .number,.table-of-progress .step :hover .is-active{background-color:#f5f5f5;width:1.8125rem;height:1.8125rem;border-radius:50%;display:inline-block}.table-of-progress .step .is-active,.table-of-progress .step :hover .number,.table-of-progress .step :hover .is-active{background-color:#333;color:#fff;position:relative}.table-of-progress .step:not(:last-of-type)::after{content:"";display:block;height:1.5rem;border-left:.1875rem solid #f5f5f5;margin-left:.8125rem}.breadcrumb{font-size:1rem;white-space:nowrap}.breadcrumb a{align-items:center;color:#e23600;display:flex;justify-content:center;padding:0 .5rem}.breadcrumb a:hover{color:#e23600}.breadcrumb li{align-items:center;display:flex}.breadcrumb li:first-child a{padding-left:0}.breadcrumb li.is-active a,.breadcrumb .table-of-progress .step :hover li.number a,.table-of-progress .step :hover .breadcrumb li.number a,.breadcrumb .table-of-progress .step :hover li.is-active a,.table-of-progress .step :hover .breadcrumb li.is-active a{color:#333;cursor:default;pointer-events:none}.breadcrumb li+li::before{color:#b0b0b0;content:"/"}.breadcrumb ul,.breadcrumb ol{align-items:flex-start;display:flex;flex-wrap:wrap;justify-content:flex-start}.breadcrumb .icon:first-child{margin-right:.5em}.breadcrumb .icon:last-child{margin-left:.5em}.breadcrumb.is-centered ol,.breadcrumb.is-centered ul{justify-content:center}.breadcrumb.is-right ol,.breadcrumb.is-right ul{justify-content:flex-end}.breadcrumb.is-small{font-size:.8rem}.breadcrumb.is-medium{font-size:1.12rem}.breadcrumb.is-large{font-size:1.43rem}.breadcrumb.has-arrow-separator li+li::before{content:"→"}.breadcrumb.has-bullet-separator li+li::before{content:"•"}.breadcrumb.has-dot-separator li+li::before{content:"·"}.breadcrumb.has-succeeds-separator li+li::before{content:"≻"}nav.breadcrumb>ul{font-size:.8rem;font-weight:600}nav.breadcrumb>ul li+li:before{font-family:"Vocabulary Icons";content:""}nav.breadcrumb>ul li:hover{text-underline-position:below}.pagination{font-size:1rem;margin:-0.25rem}.pagination.is-small{font-size:.8rem}.pagination.is-medium{font-size:1.12rem}.pagination.is-large{font-size:1.43rem}.pagination.is-rounded .pagination-previous,.image .pagination.profile .pagination-previous,.pagination.is-rounded .pagination-next,.image .pagination.profile .pagination-next{padding-left:1em;padding-right:1em;border-radius:290486px}.pagination.is-rounded .pagination-link,.image .pagination.profile .pagination-link{border-radius:290486px}.pagination,.pagination-list{align-items:center;display:flex;justify-content:center;text-align:center}.pagination-previous,.pagination-next,.pagination-link,.pagination-ellipsis{font-size:1.25rem;justify-content:center;margin:.25rem;padding-left:.5em;padding-right:.5em;text-align:center}.pagination-previous,.pagination-next,.pagination-link{border-color:#f5f5f5;color:#767676;min-width:2.5em}.pagination-previous:hover,.pagination-next:hover,.pagination-link:hover{border-color:#767676;color:#fff}.pagination-previous:focus,.pagination-next:focus,.pagination-link:focus{border-color:#3c5c99}.pagination-previous:active,.pagination-next:active,.pagination-link:active{box-shadow:inset 0 1px 2px rgba(0,0,0,.2)}.pagination-previous[disabled],.pagination-next[disabled],.pagination-link[disabled]{background-color:#f5f5f5;border-color:#f5f5f5;box-shadow:none;color:#b0b0b0;opacity:.5}.pagination-previous,.pagination-next{padding-left:.75em;padding-right:.75em;white-space:nowrap}.pagination-link.is-current{background-color:#767676;border-color:#767676;color:#fff}.pagination-ellipsis{color:#767676;pointer-events:none}.pagination-list{flex-wrap:wrap}@media screen and (max-width: 768px){.pagination{flex-wrap:wrap}.pagination-previous,.pagination-next{flex-grow:1;flex-shrink:1}.pagination-list li{flex-grow:1;flex-shrink:1}}@media screen and (min-width: 769px),print{.pagination-list{flex-grow:1;flex-shrink:1;justify-content:flex-start;order:1}.pagination-previous{order:2}.pagination-next{order:3}.pagination{justify-content:space-between}.pagination.is-centered .pagination-previous{order:1}.pagination.is-centered .pagination-list{justify-content:center;order:2}.pagination.is-centered .pagination-next{order:3}.pagination.is-right .pagination-previous{order:1}.pagination.is-right .pagination-next{order:2}.pagination.is-right .pagination-list{justify-content:flex-end;order:3}}.pagination .pagination-list .common,.pagination .pagination-list .inactive-grey,.pagination .pagination-list .inactive{font-weight:bold;font-family:"Roboto Condensed",sans-serif;line-height:1.875}.pagination .pagination-list .common .common-link,.pagination .pagination-list .inactive-grey .common-link,.pagination .pagination-list .inactive-grey .inactive-link,.pagination .pagination-list .inactive .common-link,.pagination .pagination-list .inactive .inactive-link{border-radius:0;text-decoration:none}.pagination .pagination-list .inactive .inactive-link{background-color:#f5f5f5}.pagination .pagination-list .inactive :hover{background-color:#767676}.pagination .pagination-list .inactive-grey .inactive-link{background-color:#fff}.pagination .pagination-list .inactive-grey :hover{background-color:#767676}.level{align-items:center;justify-content:space-between}.level code{border-radius:4px}.level img{display:inline-block;vertical-align:top}.level.is-mobile{display:flex}.level.is-mobile .level-left,.level.is-mobile .level-right{display:flex}.level.is-mobile .level-left+.level-right{margin-top:0}.level.is-mobile .level-item:not(:last-child){margin-bottom:0;margin-right:.75rem}.level.is-mobile .level-item:not(.is-narrow){flex-grow:1}@media screen and (min-width: 769px),print{.level{display:flex}.level>.level-item:not(.is-narrow){flex-grow:1}}.level-item{align-items:center;display:flex;flex-basis:auto;flex-grow:0;flex-shrink:0;justify-content:center}.level-item .title,.level-item .subtitle{margin-bottom:0}@media screen and (max-width: 768px){.level-item:not(:last-child){margin-bottom:.75rem}}.level-left,.level-right{flex-basis:auto;flex-grow:0;flex-shrink:0}.level-left .level-item.is-flexible,.level-right .level-item.is-flexible{flex-grow:1}@media screen and (min-width: 769px),print{.level-left .level-item:not(:last-child),.level-right .level-item:not(:last-child){margin-right:.75rem}}.level-left{align-items:center;justify-content:flex-start}@media screen and (max-width: 768px){.level-left+.level-right{margin-top:1.5rem}}@media screen and (min-width: 769px),print{.level-left{display:flex}}.level-right{align-items:center;justify-content:flex-end}@media screen and (min-width: 769px),print{.level-right{display:flex}}.cc-global-header{position:relative;background-color:#000;color:#fff;z-index:90}.cc-global-header.is-active .global-header-content,.table-of-progress .step :hover .cc-global-header.number .global-header-content,.table-of-progress .step :hover .cc-global-header.is-active .global-header-content{max-height:60rem;padding-top:1.5rem;padding-bottom:1.5rem}.cc-global-header .open-tab{position:absolute;padding:.5rem 1rem;right:0;bottom:-2rem;background-color:#000;color:#fff;border-radius:0 0 .25rem .25rem}.cc-global-header .global-header-content{max-height:0;padding-top:0;padding-bottom:0;overflow:hidden;transition:all 1s ease}.cc-global-header .global-header-content .global-header-header{padding-top:1rem}.cc-global-header .global-header-content .global-header-header .main-logo svg{width:16rem}.cc-global-header .global-header-content .donate-section h5{color:#fff}.cc-global-header .global-header-content .donate-section .donate{margin-top:1.5rem;color:#000}.cc-global-header .global-header-content .donate-section .donate svg{margin-right:1rem;width:2rem;height:2rem}.cc-global-header .global-header-content .products{padding-bottom:1rem}.cc-global-header .global-header-content .products .product-list{display:grid;grid-gap:1rem;grid-template-columns:repeat(3, auto);width:100%}.cc-global-header .global-header-content .products .product-list .product-item{flex-direction:column;align-items:flex-start;flex-shrink:1;color:#fff}.cc-global-header .global-header-content .products .product-list .product-item strong{display:flex;color:#05b5da;line-height:1.2rem;margin-bottom:.5rem}.cc-global-header .global-header-content .products .product-list .product-item strong:after{content:"";display:inline-block;width:1.2rem;height:1.2rem;margin-left:.5rem;background-image:url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 6C7.55228 6 8 5.55228 8 5C8 4.44772 7.55228 4 7 4L7 6ZM17 13C17 12.4477 16.5523 12 16 12C15.4477 12 15 12.4477 15 13H17ZM7 4L4 4L4 6L7 6L7 4ZM2 6V16H4V6H2ZM4 18H15V16H4V18ZM17 16V13H15V16H17ZM15 18C16.1046 18 17 17.1046 17 16H15H15V18ZM2 16C2 17.1046 2.89543 18 4 18V16L4 16H2ZM4 4C2.89543 4 2 4.89543 2 6H4L4 6L4 4Z' fill='%2305B5DA'/%3E%3Cpath d='M8.29289 10.2656C7.90237 10.6562 7.90237 11.2893 8.29289 11.6798C8.68342 12.0704 9.31658 12.0704 9.70711 11.6798L8.29289 10.2656ZM16.9727 3H17.9727V2H16.9727V3ZM15.9727 9C15.9727 9.55228 16.4205 10 16.9727 10C17.525 10 17.9727 9.55228 17.9727 9H15.9727ZM11 2C10.4477 2 10 2.44772 10 3C10 3.55228 10.4477 4 11 4V2ZM9.70711 11.6798L17.6799 3.70711L16.2656 2.29289L8.29289 10.2656L9.70711 11.6798ZM15.9727 3V9H17.9727V3H15.9727ZM16.9727 2H11V4H16.9727V2Z' fill='%2305B5DA'/%3E%3C/svg%3E%0A")}.cc-global-header .global-header-content .products .product-list .product-item:hover strong{text-decoration:underline}@media screen and (min-width: 769px),print{.cc-global-header{padding:0 1.5rem}}@media screen and (max-width: 768px){.cc-global-header{padding-right:2rem;padding-left:2rem}.cc-global-header .global-header-header .main-logo svg{width:14rem}.cc-global-header .global-header-header{text-align:center}.cc-global-header .donate-section{text-align:center}.cc-global-header .donate-section h5{line-height:2rem}.cc-global-header .donate-section .donate{margin-top:.5rem}.cc-global-header .products .product-list{grid-template-columns:repeat(2, auto)}}.navbar{background-color:#fff;min-height:3.25rem;position:relative;z-index:30}.navbar.is-white{background-color:#fff;color:#000}.navbar.is-white .navbar-brand>.navbar-item,.navbar.is-white .navbar-brand .navbar-link{color:#000}.navbar.is-white .navbar-brand>a.navbar-item:focus,.navbar.is-white .navbar-brand>a.navbar-item:hover,.navbar.is-white .navbar-brand>a.navbar-item.is-active,.navbar.is-white .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-white .navbar-brand>a.navbar-item.number,.navbar.is-white .navbar-brand .navbar-link:focus,.navbar.is-white .navbar-brand .navbar-link:hover,.navbar.is-white .navbar-brand .navbar-link.is-active,.navbar.is-white .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-white .navbar-brand .navbar-link.number{background-color:#f2f2f2;color:#000}.navbar.is-white .navbar-brand .navbar-link::after{border-color:#000}.navbar.is-white .navbar-burger{color:#000}@media screen and (min-width: 1024px){.navbar.is-white .navbar-start>.navbar-item,.navbar.is-white .navbar-start .navbar-link,.navbar.is-white .navbar-end>.navbar-item,.navbar.is-white .navbar-end .navbar-link{color:#000}.navbar.is-white .navbar-start>a.navbar-item:focus,.navbar.is-white .navbar-start>a.navbar-item:hover,.navbar.is-white .navbar-start>a.navbar-item.is-active,.navbar.is-white .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-white .navbar-start>a.navbar-item.number,.navbar.is-white .navbar-start .navbar-link:focus,.navbar.is-white .navbar-start .navbar-link:hover,.navbar.is-white .navbar-start .navbar-link.is-active,.navbar.is-white .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-white .navbar-start .navbar-link.number,.navbar.is-white .navbar-end>a.navbar-item:focus,.navbar.is-white .navbar-end>a.navbar-item:hover,.navbar.is-white .navbar-end>a.navbar-item.is-active,.navbar.is-white .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-white .navbar-end>a.navbar-item.number,.navbar.is-white .navbar-end .navbar-link:focus,.navbar.is-white .navbar-end .navbar-link:hover,.navbar.is-white .navbar-end .navbar-link.is-active,.navbar.is-white .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-white .navbar-end .navbar-link.number{background-color:#f2f2f2;color:#000}.navbar.is-white .navbar-start .navbar-link::after,.navbar.is-white .navbar-end .navbar-link::after{border-color:#000}.navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-white .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-white .navbar-item.has-dropdown.number .navbar-link{background-color:#f2f2f2;color:#000}.navbar.is-white .navbar-dropdown a.navbar-item.is-active,.navbar.is-white .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-white .navbar-dropdown a.navbar-item.number{background-color:#fff;color:#000}}.navbar.is-black{background-color:#000;color:#fff}.navbar.is-black .navbar-brand>.navbar-item,.navbar.is-black .navbar-brand .navbar-link{color:#fff}.navbar.is-black .navbar-brand>a.navbar-item:focus,.navbar.is-black .navbar-brand>a.navbar-item:hover,.navbar.is-black .navbar-brand>a.navbar-item.is-active,.navbar.is-black .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-black .navbar-brand>a.navbar-item.number,.navbar.is-black .navbar-brand .navbar-link:focus,.navbar.is-black .navbar-brand .navbar-link:hover,.navbar.is-black .navbar-brand .navbar-link.is-active,.navbar.is-black .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-black .navbar-brand .navbar-link.number{background-color:#000;color:#fff}.navbar.is-black .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-black .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-black .navbar-start>.navbar-item,.navbar.is-black .navbar-start .navbar-link,.navbar.is-black .navbar-end>.navbar-item,.navbar.is-black .navbar-end .navbar-link{color:#fff}.navbar.is-black .navbar-start>a.navbar-item:focus,.navbar.is-black .navbar-start>a.navbar-item:hover,.navbar.is-black .navbar-start>a.navbar-item.is-active,.navbar.is-black .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-black .navbar-start>a.navbar-item.number,.navbar.is-black .navbar-start .navbar-link:focus,.navbar.is-black .navbar-start .navbar-link:hover,.navbar.is-black .navbar-start .navbar-link.is-active,.navbar.is-black .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-black .navbar-start .navbar-link.number,.navbar.is-black .navbar-end>a.navbar-item:focus,.navbar.is-black .navbar-end>a.navbar-item:hover,.navbar.is-black .navbar-end>a.navbar-item.is-active,.navbar.is-black .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-black .navbar-end>a.navbar-item.number,.navbar.is-black .navbar-end .navbar-link:focus,.navbar.is-black .navbar-end .navbar-link:hover,.navbar.is-black .navbar-end .navbar-link.is-active,.navbar.is-black .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-black .navbar-end .navbar-link.number{background-color:#000;color:#fff}.navbar.is-black .navbar-start .navbar-link::after,.navbar.is-black .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-black .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-black .navbar-item.has-dropdown.number .navbar-link{background-color:#000;color:#fff}.navbar.is-black .navbar-dropdown a.navbar-item.is-active,.navbar.is-black .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-black .navbar-dropdown a.navbar-item.number{background-color:#000;color:#fff}}.navbar.is-light{background-color:#f5f5f5;color:rgba(0,0,0,.7)}.navbar.is-light .navbar-brand>.navbar-item,.navbar.is-light .navbar-brand .navbar-link{color:rgba(0,0,0,.7)}.navbar.is-light .navbar-brand>a.navbar-item:focus,.navbar.is-light .navbar-brand>a.navbar-item:hover,.navbar.is-light .navbar-brand>a.navbar-item.is-active,.navbar.is-light .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-light .navbar-brand>a.navbar-item.number,.navbar.is-light .navbar-brand .navbar-link:focus,.navbar.is-light .navbar-brand .navbar-link:hover,.navbar.is-light .navbar-brand .navbar-link.is-active,.navbar.is-light .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-light .navbar-brand .navbar-link.number{background-color:#e8e8e8;color:rgba(0,0,0,.7)}.navbar.is-light .navbar-brand .navbar-link::after{border-color:rgba(0,0,0,.7)}.navbar.is-light .navbar-burger{color:rgba(0,0,0,.7)}@media screen and (min-width: 1024px){.navbar.is-light .navbar-start>.navbar-item,.navbar.is-light .navbar-start .navbar-link,.navbar.is-light .navbar-end>.navbar-item,.navbar.is-light .navbar-end .navbar-link{color:rgba(0,0,0,.7)}.navbar.is-light .navbar-start>a.navbar-item:focus,.navbar.is-light .navbar-start>a.navbar-item:hover,.navbar.is-light .navbar-start>a.navbar-item.is-active,.navbar.is-light .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-light .navbar-start>a.navbar-item.number,.navbar.is-light .navbar-start .navbar-link:focus,.navbar.is-light .navbar-start .navbar-link:hover,.navbar.is-light .navbar-start .navbar-link.is-active,.navbar.is-light .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-light .navbar-start .navbar-link.number,.navbar.is-light .navbar-end>a.navbar-item:focus,.navbar.is-light .navbar-end>a.navbar-item:hover,.navbar.is-light .navbar-end>a.navbar-item.is-active,.navbar.is-light .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-light .navbar-end>a.navbar-item.number,.navbar.is-light .navbar-end .navbar-link:focus,.navbar.is-light .navbar-end .navbar-link:hover,.navbar.is-light .navbar-end .navbar-link.is-active,.navbar.is-light .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-light .navbar-end .navbar-link.number{background-color:#e8e8e8;color:rgba(0,0,0,.7)}.navbar.is-light .navbar-start .navbar-link::after,.navbar.is-light .navbar-end .navbar-link::after{border-color:rgba(0,0,0,.7)}.navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-light .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-light .navbar-item.has-dropdown.number .navbar-link{background-color:#e8e8e8;color:rgba(0,0,0,.7)}.navbar.is-light .navbar-dropdown a.navbar-item.is-active,.navbar.is-light .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-light .navbar-dropdown a.navbar-item.number{background-color:#f5f5f5;color:rgba(0,0,0,.7)}}.navbar.is-dark{background-color:#363636;color:#fff}.navbar.is-dark .navbar-brand>.navbar-item,.navbar.is-dark .navbar-brand .navbar-link{color:#fff}.navbar.is-dark .navbar-brand>a.navbar-item:focus,.navbar.is-dark .navbar-brand>a.navbar-item:hover,.navbar.is-dark .navbar-brand>a.navbar-item.is-active,.navbar.is-dark .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-dark .navbar-brand>a.navbar-item.number,.navbar.is-dark .navbar-brand .navbar-link:focus,.navbar.is-dark .navbar-brand .navbar-link:hover,.navbar.is-dark .navbar-brand .navbar-link.is-active,.navbar.is-dark .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-dark .navbar-brand .navbar-link.number{background-color:#292929;color:#fff}.navbar.is-dark .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-dark .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-dark .navbar-start>.navbar-item,.navbar.is-dark .navbar-start .navbar-link,.navbar.is-dark .navbar-end>.navbar-item,.navbar.is-dark .navbar-end .navbar-link{color:#fff}.navbar.is-dark .navbar-start>a.navbar-item:focus,.navbar.is-dark .navbar-start>a.navbar-item:hover,.navbar.is-dark .navbar-start>a.navbar-item.is-active,.navbar.is-dark .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-dark .navbar-start>a.navbar-item.number,.navbar.is-dark .navbar-start .navbar-link:focus,.navbar.is-dark .navbar-start .navbar-link:hover,.navbar.is-dark .navbar-start .navbar-link.is-active,.navbar.is-dark .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-dark .navbar-start .navbar-link.number,.navbar.is-dark .navbar-end>a.navbar-item:focus,.navbar.is-dark .navbar-end>a.navbar-item:hover,.navbar.is-dark .navbar-end>a.navbar-item.is-active,.navbar.is-dark .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-dark .navbar-end>a.navbar-item.number,.navbar.is-dark .navbar-end .navbar-link:focus,.navbar.is-dark .navbar-end .navbar-link:hover,.navbar.is-dark .navbar-end .navbar-link.is-active,.navbar.is-dark .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-dark .navbar-end .navbar-link.number{background-color:#292929;color:#fff}.navbar.is-dark .navbar-start .navbar-link::after,.navbar.is-dark .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-dark .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-dark .navbar-item.has-dropdown.number .navbar-link{background-color:#292929;color:#fff}.navbar.is-dark .navbar-dropdown a.navbar-item.is-active,.navbar.is-dark .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-dark .navbar-dropdown a.navbar-item.number{background-color:#363636;color:#fff}}.navbar.is-primary{background-color:#e23600;color:#fff}.navbar.is-primary .navbar-brand>.navbar-item,.navbar.is-primary .navbar-brand .navbar-link{color:#fff}.navbar.is-primary .navbar-brand>a.navbar-item:focus,.navbar.is-primary .navbar-brand>a.navbar-item:hover,.navbar.is-primary .navbar-brand>a.navbar-item.is-active,.navbar.is-primary .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-primary .navbar-brand>a.navbar-item.number,.navbar.is-primary .navbar-brand .navbar-link:focus,.navbar.is-primary .navbar-brand .navbar-link:hover,.navbar.is-primary .navbar-brand .navbar-link.is-active,.navbar.is-primary .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-primary .navbar-brand .navbar-link.number{background-color:#c93000;color:#fff}.navbar.is-primary .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-primary .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-primary .navbar-start>.navbar-item,.navbar.is-primary .navbar-start .navbar-link,.navbar.is-primary .navbar-end>.navbar-item,.navbar.is-primary .navbar-end .navbar-link{color:#fff}.navbar.is-primary .navbar-start>a.navbar-item:focus,.navbar.is-primary .navbar-start>a.navbar-item:hover,.navbar.is-primary .navbar-start>a.navbar-item.is-active,.navbar.is-primary .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-primary .navbar-start>a.navbar-item.number,.navbar.is-primary .navbar-start .navbar-link:focus,.navbar.is-primary .navbar-start .navbar-link:hover,.navbar.is-primary .navbar-start .navbar-link.is-active,.navbar.is-primary .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-primary .navbar-start .navbar-link.number,.navbar.is-primary .navbar-end>a.navbar-item:focus,.navbar.is-primary .navbar-end>a.navbar-item:hover,.navbar.is-primary .navbar-end>a.navbar-item.is-active,.navbar.is-primary .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-primary .navbar-end>a.navbar-item.number,.navbar.is-primary .navbar-end .navbar-link:focus,.navbar.is-primary .navbar-end .navbar-link:hover,.navbar.is-primary .navbar-end .navbar-link.is-active,.navbar.is-primary .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-primary .navbar-end .navbar-link.number{background-color:#c93000;color:#fff}.navbar.is-primary .navbar-start .navbar-link::after,.navbar.is-primary .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-primary .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-primary .navbar-item.has-dropdown.number .navbar-link{background-color:#c93000;color:#fff}.navbar.is-primary .navbar-dropdown a.navbar-item.is-active,.navbar.is-primary .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-primary .navbar-dropdown a.navbar-item.number{background-color:#e23600;color:#fff}}.navbar.is-link{background-color:#e23600;color:#fff}.navbar.is-link .navbar-brand>.navbar-item,.navbar.is-link .navbar-brand .navbar-link{color:#fff}.navbar.is-link .navbar-brand>a.navbar-item:focus,.navbar.is-link .navbar-brand>a.navbar-item:hover,.navbar.is-link .navbar-brand>a.navbar-item.is-active,.navbar.is-link .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-link .navbar-brand>a.navbar-item.number,.navbar.is-link .navbar-brand .navbar-link:focus,.navbar.is-link .navbar-brand .navbar-link:hover,.navbar.is-link .navbar-brand .navbar-link.is-active,.navbar.is-link .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-link .navbar-brand .navbar-link.number{background-color:#c93000;color:#fff}.navbar.is-link .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-link .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-link .navbar-start>.navbar-item,.navbar.is-link .navbar-start .navbar-link,.navbar.is-link .navbar-end>.navbar-item,.navbar.is-link .navbar-end .navbar-link{color:#fff}.navbar.is-link .navbar-start>a.navbar-item:focus,.navbar.is-link .navbar-start>a.navbar-item:hover,.navbar.is-link .navbar-start>a.navbar-item.is-active,.navbar.is-link .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-link .navbar-start>a.navbar-item.number,.navbar.is-link .navbar-start .navbar-link:focus,.navbar.is-link .navbar-start .navbar-link:hover,.navbar.is-link .navbar-start .navbar-link.is-active,.navbar.is-link .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-link .navbar-start .navbar-link.number,.navbar.is-link .navbar-end>a.navbar-item:focus,.navbar.is-link .navbar-end>a.navbar-item:hover,.navbar.is-link .navbar-end>a.navbar-item.is-active,.navbar.is-link .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-link .navbar-end>a.navbar-item.number,.navbar.is-link .navbar-end .navbar-link:focus,.navbar.is-link .navbar-end .navbar-link:hover,.navbar.is-link .navbar-end .navbar-link.is-active,.navbar.is-link .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-link .navbar-end .navbar-link.number{background-color:#c93000;color:#fff}.navbar.is-link .navbar-start .navbar-link::after,.navbar.is-link .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-link .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-link .navbar-item.has-dropdown.number .navbar-link{background-color:#c93000;color:#fff}.navbar.is-link .navbar-dropdown a.navbar-item.is-active,.navbar.is-link .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-link .navbar-dropdown a.navbar-item.number{background-color:#e23600;color:#fff}}.navbar.is-info{background-color:#1950b8;color:#fff}.navbar.is-info .navbar-brand>.navbar-item,.navbar.is-info .navbar-brand .navbar-link{color:#fff}.navbar.is-info .navbar-brand>a.navbar-item:focus,.navbar.is-info .navbar-brand>a.navbar-item:hover,.navbar.is-info .navbar-brand>a.navbar-item.is-active,.navbar.is-info .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-info .navbar-brand>a.navbar-item.number,.navbar.is-info .navbar-brand .navbar-link:focus,.navbar.is-info .navbar-brand .navbar-link:hover,.navbar.is-info .navbar-brand .navbar-link.is-active,.navbar.is-info .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-info .navbar-brand .navbar-link.number{background-color:#1646a2;color:#fff}.navbar.is-info .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-info .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-info .navbar-start>.navbar-item,.navbar.is-info .navbar-start .navbar-link,.navbar.is-info .navbar-end>.navbar-item,.navbar.is-info .navbar-end .navbar-link{color:#fff}.navbar.is-info .navbar-start>a.navbar-item:focus,.navbar.is-info .navbar-start>a.navbar-item:hover,.navbar.is-info .navbar-start>a.navbar-item.is-active,.navbar.is-info .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-info .navbar-start>a.navbar-item.number,.navbar.is-info .navbar-start .navbar-link:focus,.navbar.is-info .navbar-start .navbar-link:hover,.navbar.is-info .navbar-start .navbar-link.is-active,.navbar.is-info .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-info .navbar-start .navbar-link.number,.navbar.is-info .navbar-end>a.navbar-item:focus,.navbar.is-info .navbar-end>a.navbar-item:hover,.navbar.is-info .navbar-end>a.navbar-item.is-active,.navbar.is-info .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-info .navbar-end>a.navbar-item.number,.navbar.is-info .navbar-end .navbar-link:focus,.navbar.is-info .navbar-end .navbar-link:hover,.navbar.is-info .navbar-end .navbar-link.is-active,.navbar.is-info .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-info .navbar-end .navbar-link.number{background-color:#1646a2;color:#fff}.navbar.is-info .navbar-start .navbar-link::after,.navbar.is-info .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-info .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-info .navbar-item.has-dropdown.number .navbar-link{background-color:#1646a2;color:#fff}.navbar.is-info .navbar-dropdown a.navbar-item.is-active,.navbar.is-info .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-info .navbar-dropdown a.navbar-item.number{background-color:#1950b8;color:#fff}}.navbar.is-success{background-color:#008300;color:#fff}.navbar.is-success .navbar-brand>.navbar-item,.navbar.is-success .navbar-brand .navbar-link{color:#fff}.navbar.is-success .navbar-brand>a.navbar-item:focus,.navbar.is-success .navbar-brand>a.navbar-item:hover,.navbar.is-success .navbar-brand>a.navbar-item.is-active,.navbar.is-success .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-success .navbar-brand>a.navbar-item.number,.navbar.is-success .navbar-brand .navbar-link:focus,.navbar.is-success .navbar-brand .navbar-link:hover,.navbar.is-success .navbar-brand .navbar-link.is-active,.navbar.is-success .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-success .navbar-brand .navbar-link.number{background-color:#006a00;color:#fff}.navbar.is-success .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-success .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-success .navbar-start>.navbar-item,.navbar.is-success .navbar-start .navbar-link,.navbar.is-success .navbar-end>.navbar-item,.navbar.is-success .navbar-end .navbar-link{color:#fff}.navbar.is-success .navbar-start>a.navbar-item:focus,.navbar.is-success .navbar-start>a.navbar-item:hover,.navbar.is-success .navbar-start>a.navbar-item.is-active,.navbar.is-success .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-success .navbar-start>a.navbar-item.number,.navbar.is-success .navbar-start .navbar-link:focus,.navbar.is-success .navbar-start .navbar-link:hover,.navbar.is-success .navbar-start .navbar-link.is-active,.navbar.is-success .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-success .navbar-start .navbar-link.number,.navbar.is-success .navbar-end>a.navbar-item:focus,.navbar.is-success .navbar-end>a.navbar-item:hover,.navbar.is-success .navbar-end>a.navbar-item.is-active,.navbar.is-success .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-success .navbar-end>a.navbar-item.number,.navbar.is-success .navbar-end .navbar-link:focus,.navbar.is-success .navbar-end .navbar-link:hover,.navbar.is-success .navbar-end .navbar-link.is-active,.navbar.is-success .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-success .navbar-end .navbar-link.number{background-color:#006a00;color:#fff}.navbar.is-success .navbar-start .navbar-link::after,.navbar.is-success .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-success .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-success .navbar-item.has-dropdown.number .navbar-link{background-color:#006a00;color:#fff}.navbar.is-success .navbar-dropdown a.navbar-item.is-active,.navbar.is-success .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-success .navbar-dropdown a.navbar-item.number{background-color:#008300;color:#fff}}.navbar.is-warning{background-color:#f2ab20;color:#fff}.navbar.is-warning .navbar-brand>.navbar-item,.navbar.is-warning .navbar-brand .navbar-link{color:#fff}.navbar.is-warning .navbar-brand>a.navbar-item:focus,.navbar.is-warning .navbar-brand>a.navbar-item:hover,.navbar.is-warning .navbar-brand>a.navbar-item.is-active,.navbar.is-warning .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-warning .navbar-brand>a.navbar-item.number,.navbar.is-warning .navbar-brand .navbar-link:focus,.navbar.is-warning .navbar-brand .navbar-link:hover,.navbar.is-warning .navbar-brand .navbar-link.is-active,.navbar.is-warning .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-warning .navbar-brand .navbar-link.number{background-color:#eba00e;color:#fff}.navbar.is-warning .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-warning .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-warning .navbar-start>.navbar-item,.navbar.is-warning .navbar-start .navbar-link,.navbar.is-warning .navbar-end>.navbar-item,.navbar.is-warning .navbar-end .navbar-link{color:#fff}.navbar.is-warning .navbar-start>a.navbar-item:focus,.navbar.is-warning .navbar-start>a.navbar-item:hover,.navbar.is-warning .navbar-start>a.navbar-item.is-active,.navbar.is-warning .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-warning .navbar-start>a.navbar-item.number,.navbar.is-warning .navbar-start .navbar-link:focus,.navbar.is-warning .navbar-start .navbar-link:hover,.navbar.is-warning .navbar-start .navbar-link.is-active,.navbar.is-warning .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-warning .navbar-start .navbar-link.number,.navbar.is-warning .navbar-end>a.navbar-item:focus,.navbar.is-warning .navbar-end>a.navbar-item:hover,.navbar.is-warning .navbar-end>a.navbar-item.is-active,.navbar.is-warning .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-warning .navbar-end>a.navbar-item.number,.navbar.is-warning .navbar-end .navbar-link:focus,.navbar.is-warning .navbar-end .navbar-link:hover,.navbar.is-warning .navbar-end .navbar-link.is-active,.navbar.is-warning .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-warning .navbar-end .navbar-link.number{background-color:#eba00e;color:#fff}.navbar.is-warning .navbar-start .navbar-link::after,.navbar.is-warning .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-warning .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-warning .navbar-item.has-dropdown.number .navbar-link{background-color:#eba00e;color:#fff}.navbar.is-warning .navbar-dropdown a.navbar-item.is-active,.navbar.is-warning .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-warning .navbar-dropdown a.navbar-item.number{background-color:#f2ab20;color:#fff}}.navbar.is-danger{background-color:#c83b1e;color:#fff}.navbar.is-danger .navbar-brand>.navbar-item,.navbar.is-danger .navbar-brand .navbar-link{color:#fff}.navbar.is-danger .navbar-brand>a.navbar-item:focus,.navbar.is-danger .navbar-brand>a.navbar-item:hover,.navbar.is-danger .navbar-brand>a.navbar-item.is-active,.navbar.is-danger .table-of-progress .step :hover .navbar-brand>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-danger .navbar-brand>a.navbar-item.number,.navbar.is-danger .navbar-brand .navbar-link:focus,.navbar.is-danger .navbar-brand .navbar-link:hover,.navbar.is-danger .navbar-brand .navbar-link.is-active,.navbar.is-danger .navbar-brand .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-danger .navbar-brand .navbar-link.number{background-color:#b2341b;color:#fff}.navbar.is-danger .navbar-brand .navbar-link::after{border-color:#fff}.navbar.is-danger .navbar-burger{color:#fff}@media screen and (min-width: 1024px){.navbar.is-danger .navbar-start>.navbar-item,.navbar.is-danger .navbar-start .navbar-link,.navbar.is-danger .navbar-end>.navbar-item,.navbar.is-danger .navbar-end .navbar-link{color:#fff}.navbar.is-danger .navbar-start>a.navbar-item:focus,.navbar.is-danger .navbar-start>a.navbar-item:hover,.navbar.is-danger .navbar-start>a.navbar-item.is-active,.navbar.is-danger .table-of-progress .step :hover .navbar-start>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-danger .navbar-start>a.navbar-item.number,.navbar.is-danger .navbar-start .navbar-link:focus,.navbar.is-danger .navbar-start .navbar-link:hover,.navbar.is-danger .navbar-start .navbar-link.is-active,.navbar.is-danger .navbar-start .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-danger .navbar-start .navbar-link.number,.navbar.is-danger .navbar-end>a.navbar-item:focus,.navbar.is-danger .navbar-end>a.navbar-item:hover,.navbar.is-danger .navbar-end>a.navbar-item.is-active,.navbar.is-danger .table-of-progress .step :hover .navbar-end>a.navbar-item.number,.table-of-progress .step :hover .navbar.is-danger .navbar-end>a.navbar-item.number,.navbar.is-danger .navbar-end .navbar-link:focus,.navbar.is-danger .navbar-end .navbar-link:hover,.navbar.is-danger .navbar-end .navbar-link.is-active,.navbar.is-danger .navbar-end .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-danger .navbar-end .navbar-link.number{background-color:#b2341b;color:#fff}.navbar.is-danger .navbar-start .navbar-link::after,.navbar.is-danger .navbar-end .navbar-link::after{border-color:#fff}.navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,.navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,.navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-danger .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-danger .navbar-item.has-dropdown.number .navbar-link{background-color:#b2341b;color:#fff}.navbar.is-danger .navbar-dropdown a.navbar-item.is-active,.navbar.is-danger .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-danger .navbar-dropdown a.navbar-item.number{background-color:#c83b1e;color:#fff}}.navbar>.container{align-items:stretch;display:flex;min-height:3.25rem;width:100%}.navbar.has-shadow{box-shadow:0 2px 0 0 #f5f5f5}.navbar.is-fixed-bottom,.navbar.is-fixed-top{left:0;position:fixed;right:0;z-index:30}.navbar.is-fixed-bottom{bottom:0}.navbar.is-fixed-bottom.has-shadow{box-shadow:0 -2px 0 0 #f5f5f5}.navbar.is-fixed-top{top:0}html.has-navbar-fixed-top,body.has-navbar-fixed-top{padding-top:3.25rem}html.has-navbar-fixed-bottom,body.has-navbar-fixed-bottom{padding-bottom:3.25rem}.navbar-brand,.navbar-tabs{align-items:stretch;display:flex;flex-shrink:0;min-height:3.25rem}.navbar-brand a.navbar-item:focus,.navbar-brand a.navbar-item:hover{background-color:rgba(0,0,0,0)}.navbar-tabs{-webkit-overflow-scrolling:touch;max-width:100vw;overflow-x:auto;overflow-y:hidden}.navbar-burger{color:#767676;cursor:pointer;display:block;height:3.25rem;position:relative;width:3.25rem;margin-left:auto}.navbar-burger span{background-color:currentColor;display:block;height:1px;left:calc(50% - 8px);position:absolute;transform-origin:center;transition-duration:86ms;transition-property:background-color,opacity,transform;transition-timing-function:ease-out;width:16px}.navbar-burger span:nth-child(1){top:calc(50% - 6px)}.navbar-burger span:nth-child(2){top:calc(50% - 1px)}.navbar-burger span:nth-child(3){top:calc(50% + 4px)}.navbar-burger:hover{background-color:rgba(0,0,0,.05)}.navbar-burger.is-active span:nth-child(1),.table-of-progress .step :hover .navbar-burger.number span:nth-child(1),.table-of-progress .step :hover .navbar-burger.is-active span:nth-child(1){transform:translateY(5px) rotate(45deg)}.navbar-burger.is-active span:nth-child(2),.table-of-progress .step :hover .navbar-burger.number span:nth-child(2),.table-of-progress .step :hover .navbar-burger.is-active span:nth-child(2){opacity:0}.navbar-burger.is-active span:nth-child(3),.table-of-progress .step :hover .navbar-burger.number span:nth-child(3),.table-of-progress .step :hover .navbar-burger.is-active span:nth-child(3){transform:translateY(-5px) rotate(-45deg)}.navbar-menu{display:none}.navbar-item,.navbar-link{color:#767676;display:block;line-height:1.5;padding:.5rem .75rem;position:relative}.navbar-item .icon:only-child,.navbar-link .icon:only-child{margin-left:-0.25rem;margin-right:-0.25rem}a.navbar-item,.navbar-link{cursor:pointer}a.navbar-item:focus,a.navbar-item:focus-within,a.navbar-item:hover,a.navbar-item.is-active,.table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover a.navbar-item.is-active,.navbar-link:focus,.navbar-link:focus-within,.navbar-link:hover,.navbar-link.is-active,.table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar-link.is-active{background-color:rgba(0,0,0,0);color:#333}.navbar-item{flex-grow:0;flex-shrink:0}.navbar-item img{max-height:1.75rem}.navbar-item.has-dropdown{padding:0}.navbar-item.is-expanded{flex-grow:1;flex-shrink:1}.navbar-item.is-tab{border-bottom:1px solid rgba(0,0,0,0);min-height:3.25rem;padding-bottom:calc(.5rem - 1px)}.navbar-item.is-tab:focus,.navbar-item.is-tab:hover{background-color:rgba(0,0,0,0);border-bottom-color:#e23600}.navbar-item.is-tab.is-active,.table-of-progress .step :hover .navbar-item.is-tab.number,.table-of-progress .step :hover .navbar-item.is-tab.is-active{background-color:rgba(0,0,0,0);border-bottom-color:#e23600;border-bottom-style:solid;border-bottom-width:3px;color:#e23600;padding-bottom:calc(.5rem - 3px)}.navbar-content{flex-grow:1;flex-shrink:1}.navbar-link:not(.is-arrowless){padding-right:2.5em}.navbar-link:not(.is-arrowless)::after{border-color:#e23600;margin-top:-0.375em;right:1.125em}.navbar-dropdown{font-size:.875rem;padding-bottom:.5rem;padding-top:.5rem}.navbar-dropdown .navbar-item{padding-left:1.5rem;padding-right:1.5rem}.navbar-divider{background-color:#f5f5f5;border:none;display:none;height:2px;margin:.5rem 0}@media screen and (max-width: 1023px){.navbar>.container{display:block}.navbar-brand .navbar-item,.navbar-tabs .navbar-item{align-items:center;display:flex}.navbar-link::after{display:none}.navbar-menu{background-color:#fff;box-shadow:0 8px 16px rgba(0,0,0,.1);padding:.5rem 0}.navbar-menu.is-active,.table-of-progress .step :hover .navbar-menu.number,.table-of-progress .step :hover .navbar-menu.is-active{display:block}.navbar.is-fixed-bottom-touch,.navbar.is-fixed-top-touch{left:0;position:fixed;right:0;z-index:30}.navbar.is-fixed-bottom-touch{bottom:0}.navbar.is-fixed-bottom-touch.has-shadow{box-shadow:0 -2px 3px rgba(0,0,0,.1)}.navbar.is-fixed-top-touch{top:0}.navbar.is-fixed-top .navbar-menu,.navbar.is-fixed-top-touch .navbar-menu{-webkit-overflow-scrolling:touch;max-height:calc(100vh - 3.25rem);overflow:auto}html.has-navbar-fixed-top-touch,body.has-navbar-fixed-top-touch{padding-top:3.25rem}html.has-navbar-fixed-bottom-touch,body.has-navbar-fixed-bottom-touch{padding-bottom:3.25rem}}@media screen and (min-width: 1024px){.navbar,.navbar-menu,.navbar-start,.navbar-end{align-items:stretch;display:flex}.navbar{min-height:3.25rem}.navbar.is-spaced{padding:1rem 2rem}.navbar.is-spaced .navbar-start,.navbar.is-spaced .navbar-end{align-items:center}.navbar.is-spaced a.navbar-item,.navbar.is-spaced .navbar-link{border-radius:4px}.navbar.is-transparent a.navbar-item:focus,.navbar.is-transparent a.navbar-item:hover,.navbar.is-transparent a.navbar-item.is-active,.navbar.is-transparent .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-transparent a.navbar-item.number,.navbar.is-transparent .navbar-link:focus,.navbar.is-transparent .navbar-link:hover,.navbar.is-transparent .navbar-link.is-active,.navbar.is-transparent .table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar.is-transparent .navbar-link.number{background-color:rgba(0,0,0,0) !important}.navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link,.navbar.is-transparent .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,.table-of-progress .step :hover .navbar.is-transparent .navbar-item.has-dropdown.number .navbar-link,.navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus .navbar-link,.navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus-within .navbar-link,.navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link{background-color:rgba(0,0,0,0) !important}.navbar.is-transparent .navbar-dropdown a.navbar-item:focus,.navbar.is-transparent .navbar-dropdown a.navbar-item:hover{background-color:#f5f5f5;color:#000}.navbar.is-transparent .navbar-dropdown a.navbar-item.is-active,.navbar.is-transparent .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar.is-transparent .navbar-dropdown a.navbar-item.number{background-color:#f5f5f5;color:#e23600}.navbar-burger{display:none}.navbar-item,.navbar-link{align-items:center;display:flex}.navbar-item.has-dropdown{align-items:stretch}.navbar-item.has-dropdown-up .navbar-link::after{transform:rotate(135deg) translate(0.25em, -0.25em)}.navbar-item.has-dropdown-up .navbar-dropdown{border-bottom:none;border-radius:0 0 0 0;border-top:none;bottom:100%;box-shadow:0 -8px 8px rgba(0,0,0,.1);top:auto}.navbar-item.is-active .navbar-dropdown,.table-of-progress .step :hover .navbar-item.number .navbar-dropdown,.table-of-progress .step :hover .navbar-item.is-active .navbar-dropdown,.navbar-item.is-hoverable:focus .navbar-dropdown,.navbar-item.is-hoverable:focus-within .navbar-dropdown,.navbar-item.is-hoverable:hover .navbar-dropdown{display:block}.navbar.is-spaced .navbar-item.is-active .navbar-dropdown,.navbar.is-spaced .table-of-progress .step :hover .navbar-item.number .navbar-dropdown,.table-of-progress .step :hover .navbar.is-spaced .navbar-item.number .navbar-dropdown,.navbar-item.is-active .navbar-dropdown.is-boxed,.table-of-progress .step :hover .navbar-item.number .navbar-dropdown.is-boxed,.navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown,.navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed,.navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown,.navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed,.navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown,.navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed{opacity:1;pointer-events:auto;transform:translateY(0)}.navbar-menu{flex-grow:1;flex-shrink:0}.navbar-start{justify-content:flex-start;margin-right:auto}.navbar-end{justify-content:flex-end;margin-left:auto}.navbar-dropdown{background-color:#fff;border-bottom-left-radius:0;border-bottom-right-radius:0;border-top:none;box-shadow:0 8px 8px rgba(0,0,0,.1);display:none;font-size:.875rem;left:0;min-width:100%;position:absolute;top:100%;z-index:20}.navbar-dropdown .navbar-item{padding:.375rem 1rem;white-space:nowrap}.navbar-dropdown a.navbar-item{padding-right:3rem}.navbar-dropdown a.navbar-item:focus,.navbar-dropdown a.navbar-item:hover{background-color:#f5f5f5;color:#000}.navbar-dropdown a.navbar-item.is-active,.navbar-dropdown .table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover .navbar-dropdown a.navbar-item.number,.navbar-dropdown .table-of-progress .step :hover a.navbar-item.is-active,.table-of-progress .step :hover .navbar-dropdown a.navbar-item.is-active{background-color:#f5f5f5;color:#e23600}.navbar.is-spaced .navbar-dropdown,.navbar-dropdown.is-boxed{border-radius:6px;border-top:none;box-shadow:0 8px 8px rgba(0,0,0,.1),0 0 0 1px rgba(0,0,0,.1);display:block;opacity:0;pointer-events:none;top:calc(100% + (-4px));transform:translateY(-5px);transition-duration:86ms;transition-property:opacity,transform}.navbar-dropdown.is-right{left:auto;right:0}.navbar-divider{display:block}.navbar>.container .navbar-brand,.container>.navbar .navbar-brand{margin-left:-0.75rem}.navbar>.container .navbar-menu,.container>.navbar .navbar-menu{margin-right:-0.75rem}.navbar.is-fixed-bottom-desktop,.navbar.is-fixed-top-desktop{left:0;position:fixed;right:0;z-index:30}.navbar.is-fixed-bottom-desktop{bottom:0}.navbar.is-fixed-bottom-desktop.has-shadow{box-shadow:0 -2px 3px rgba(0,0,0,.1)}.navbar.is-fixed-top-desktop{top:0}html.has-navbar-fixed-top-desktop,body.has-navbar-fixed-top-desktop{padding-top:3.25rem}html.has-navbar-fixed-bottom-desktop,body.has-navbar-fixed-bottom-desktop{padding-bottom:3.25rem}html.has-spaced-navbar-fixed-top,body.has-spaced-navbar-fixed-top{padding-top:5.25rem}html.has-spaced-navbar-fixed-bottom,body.has-spaced-navbar-fixed-bottom{padding-bottom:5.25rem}a.navbar-item.is-active,.table-of-progress .step :hover a.navbar-item.number,.table-of-progress .step :hover a.navbar-item.is-active,.navbar-link.is-active,.table-of-progress .step :hover .navbar-link.number,.table-of-progress .step :hover .navbar-link.is-active{color:#333}a.navbar-item.is-active:not(:focus):not(:hover),.table-of-progress .step :hover a.navbar-item.number:not(:focus):not(:hover),.navbar-link.is-active:not(:focus):not(:hover),.table-of-progress .step :hover .navbar-link.number:not(:focus):not(:hover){background-color:rgba(0,0,0,0)}.navbar-item.has-dropdown:focus .navbar-link,.navbar-item.has-dropdown:hover .navbar-link,.navbar-item.has-dropdown.is-active .navbar-link,.table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link{background-color:rgba(0,0,0,0)}}.hero.is-fullheight-with-navbar{min-height:calc(100vh - 3.25rem)}.navbar{padding:2rem}.navbar .logo{height:46px}.navbar .navbar-burger span{height:2px}.navbar .navbar-burger{width:3.25rem}.navbar .navbar-link{text-decoration:none}.navbar .navbar-end .navbar-item{font-family:"Roboto Condensed",sans-serif;font-size:1.25rem;font-weight:bold;text-transform:uppercase;line-height:1.5;letter-spacing:2%}.navbar .navbar-end .navbar-item .icon{margin-left:.5rem}.navbar .navbar-end>.navbar-item{margin-left:2.5rem}.navbar .navbar-end .navbar-item:hover{text-decoration:none;color:#333}@media screen and (min-width: 1024px)and (max-width: 1215px){.navbar .navbar-end .navbar-item{margin-left:0;font-size:1.15rem}}.navbar.small{padding:1rem}.navbar.small .logo{height:42px}.navbar.small .navbar-menu{margin-right:20rem}.navbar.small .navbar-menu.is-active,.navbar.small .table-of-progress .step :hover .navbar-menu.number,.table-of-progress .step :hover .navbar.small .navbar-menu.number{margin-right:0}.navbar.is-compact{height:72px;display:flex}.navbar.is-compact .logo{height:36px}.navbar.is-compact .navbar-end .navbar-item{font-family:"Source Sans Pro",sans-serif;font-size:1rem;font-weight:600;text-transform:capitalize}.navbar.is-compact .navbar-end>.navbar-item{margin-left:1rem}@media screen and (max-width: 768px){.navbar.is-compact .navbar-end{display:flex;align-items:stretch;justify-content:flex-end;margin-left:auto}.navbar.is-compact .navbar-item{display:flex;align-items:center}}@media screen and (min-width: 769px),print{.navbar.is-compact .navbar-end{display:flex;align-items:stretch;justify-content:flex-end;margin-left:auto}.navbar.is-compact .navbar-item{display:flex;align-items:center}}.main-footer{background-color:#000;color:#fff;padding:2.5rem 0}.main-footer a{color:#05b5da}.main-footer a:hover{color:#05b5da;text-decoration:underline}.main-footer a.social:hover{text-decoration:none}.main-footer .main-logo{display:block}.main-footer .main-logo svg{width:13rem}.main-footer address{font-style:normal}.main-footer .footer-navigation .menu li{display:inline-block}.main-footer .footer-navigation .menu li:first-child .menu-item{padding-left:0}.main-footer .footer-navigation .menu li .menu-item{display:block;padding:1rem;font-size:1.43rem;font-style:normal;font-weight:bold}.main-footer .subscription h5{margin-bottom:1rem;color:#fff}.main-footer .subscription .newsletter{display:flex;width:70%}.main-footer .subscription .newsletter .input{background-color:rgba(0,0,0,0);border-color:#767676;color:#767676}.main-footer .subscription .newsletter .input::placeholder{color:#767676;opacity:.8}.main-footer .subscription .newsletter .button{margin-left:-1rem;border:none;background-color:#767676;color:#fff}.main-footer .subscription .newsletter .button:hover{background-color:#909090}.main-footer .donate-section h5{color:#fff}.main-footer .donate-section .donate{margin-top:1.5rem;color:#000}.main-footer .donate-section .donate svg{margin-right:1rem;width:2rem;height:2rem}@media screen and (min-width: 769px),print{.main-footer{padding:1.5rem}.main-footer .footer-navigation .menu{display:flex}}@media screen and (max-width: 768px){.main-footer{padding:1rem}.main-footer .footer-navigation{margin-bottom:1rem}.main-footer .footer-navigation .menu li{display:block}.main-footer .footer-navigation .menu li .menu-item{padding-left:0}}.github-corner{position:absolute;top:0}.github-corner.is-left-aligned{left:0;transform:scaleX(-1)}.github-corner:not(.is-left-aligned){right:0}.github-corner.is-inverted{color:#000}.github-corner.is-inverted svg{fill:#fff}.github-corner.is-inverted:hover{color:#000}.github-corner:not(.is-inverted){color:#fff}.github-corner:not(.is-inverted) svg{fill:#000}.github-corner:not(.is-inverted):hover{color:#fff}.locale{display:flex;flex-direction:row;align-items:center;font-family:"Source Sans Pro",sans-serif}.locale .select{margin-left:.5rem}.locale .icon{align-items:center;display:inline-flex;justify-content:center;padding-left:10px}.image{position:relative;overflow:hidden}.image img{display:block;width:100%}.image .image-title,.image .image-icons,.image .bookmark-icon{transition:transform .2s linear;position:absolute}.image .image-title{transform:translateY(100%);left:0;bottom:0;font-weight:600}.image .image-title.is-ellipsised:not(:hover){white-space:nowrap;width:100%;overflow:hidden;text-overflow:ellipsis}.image .image-icons{transform:translateY(-100%);left:0;top:0;font-size:1.625rem}.image .bookmark-icon{right:0;top:0;line-height:1;transform:translateY(-100%)}.image:hover .image-title,.image:hover .image-icons,.image:hover .bookmark-icon{transform:translateY(0%)}.image.is-compact .image-icons{font-size:1.3rem}.image.is-selected{border:6px solid #efbe00}.image{display:block;position:relative}.image img{display:block;height:auto;width:100%}.image img.is-rounded,.image img.profile{border-radius:290486px}.image.is-fullwidth{width:100%}.image.is-square img,.image.is-square .has-ratio,.image.is-1by1 img,.image.is-1by1 .has-ratio,.image.is-5by4 img,.image.is-5by4 .has-ratio,.image.is-4by3 img,.image.is-4by3 .has-ratio,.image.is-3by2 img,.image.is-3by2 .has-ratio,.image.is-5by3 img,.image.is-5by3 .has-ratio,.image.is-16by9 img,.image.is-16by9 .has-ratio,.image.is-2by1 img,.image.is-2by1 .has-ratio,.image.is-3by1 img,.image.is-3by1 .has-ratio,.image.is-4by5 img,.image.is-4by5 .has-ratio,.image.is-3by4 img,.image.is-3by4 .has-ratio,.image.is-2by3 img,.image.is-2by3 .has-ratio,.image.is-3by5 img,.image.is-3by5 .has-ratio,.image.is-9by16 img,.image.is-9by16 .has-ratio,.image.is-1by2 img,.image.is-1by2 .has-ratio,.image.is-1by3 img,.image.is-1by3 .has-ratio{height:100%;width:100%}.image.is-square,.image.is-1by1{padding-top:100%}.image.is-5by4{padding-top:80%}.image.is-4by3{padding-top:75%}.image.is-3by2{padding-top:66.6666%}.image.is-5by3{padding-top:60%}.image.is-16by9{padding-top:56.25%}.image.is-2by1{padding-top:50%}.image.is-3by1{padding-top:33.3333%}.image.is-4by5{padding-top:125%}.image.is-3by4{padding-top:133.3333%}.image.is-2by3{padding-top:150%}.image.is-3by5{padding-top:166.6666%}.image.is-9by16{padding-top:177.7777%}.image.is-1by2{padding-top:200%}.image.is-1by3{padding-top:300%}.image.is-16x16{height:16px;width:16px}.image.is-24x24{height:24px;width:24px}.image.is-32x32{height:32px;width:32px}.image.is-48x48{height:48px;width:48px}.image.is-64x64{height:64px;width:64px}.image.is-96x96{height:96px;width:96px}.image.is-128x128{height:128px;width:128px}.image .profile{border:solid .1875em #333;min-width:60px;object-fit:cover;height:100%}.content li+li{margin-top:.25em}.content p:not(:last-child),.content dl:not(:last-child),.content ol:not(:last-child),.content ul:not(:last-child),.content blockquote:not(:last-child),.content pre:not(:last-child),.content table:not(:last-child){margin-bottom:1em}.content h1,.content h2,.content h3,.content h4,.content h5,.content h6{color:#363636;font-weight:600;line-height:1.125}.content h1{font-size:2em;margin-bottom:.5em}.content h1:not(:first-child){margin-top:1em}.content h2{font-size:1.75em;margin-bottom:.5714em}.content h2:not(:first-child){margin-top:1.1428em}.content h3{font-size:1.5em;margin-bottom:.6666em}.content h3:not(:first-child){margin-top:1.3333em}.content h4{font-size:1.25em;margin-bottom:.8em}.content h5{font-size:1.125em;margin-bottom:.8888em}.content h6{font-size:1em;margin-bottom:1em}.content blockquote{background-color:#f5f5f5;border-left:5px solid #f5f5f5;padding:1.25em 1.5em}.content ol{list-style-position:outside;margin-left:2em;margin-top:1em}.content ol:not([type]){list-style-type:decimal}.content ol:not([type]).is-lower-alpha{list-style-type:lower-alpha}.content ol:not([type]).is-lower-roman{list-style-type:lower-roman}.content ol:not([type]).is-upper-alpha{list-style-type:upper-alpha}.content ol:not([type]).is-upper-roman{list-style-type:upper-roman}.content ul{list-style:disc outside;margin-left:2em;margin-top:1em}.content ul ul{list-style-type:circle;margin-top:.5em}.content ul ul ul{list-style-type:square}.content dd{margin-left:2em}.content figure{margin-left:2em;margin-right:2em;text-align:center}.content figure:not(:first-child){margin-top:2em}.content figure:not(:last-child){margin-bottom:2em}.content figure img{display:inline-block}.content figure figcaption{font-style:italic}.content pre{-webkit-overflow-scrolling:touch;overflow-x:auto;padding:1.25em 1.5em;white-space:pre;word-wrap:normal}.content sup,.content sub{font-size:75%}.content table{width:100%}.content table td,.content table th{border:1px solid #f5f5f5;border-width:0 0 1px;padding:.5em .75em;vertical-align:top}.content table th{color:#363636}.content table th:not([align]){text-align:inherit}.content table thead td,.content table thead th{border-width:0 0 2px;color:#363636}.content table tfoot td,.content table tfoot th{border-width:2px 0 0;color:#363636}.content table tbody tr:last-child td,.content table tbody tr:last-child th{border-bottom-width:0}.content .tabs li+li{margin-top:0}.content.is-small{font-size:.8rem}.content.is-medium{font-size:1.12rem}.content.is-large{font-size:1.43rem}body{color:#333}a,a:hover{color:#3c5c99}.breadcrumb a,.breadcrumb a:hover{color:#3c5c99}.button.case{background-color:#e23600;border-color:#e23600;color:#fff}.button.case:hover{background-color:#ff6933;border-color:#ff6933}.button.case.tag{background-color:#fff;color:#767676}.button.case.tag.outline{border-color:#e23600;text-decoration:none}.button.case.tag:hover,.button.case.tag.selected{background-color:#e23600;border-color:#e23600;color:#fff}.button.scholarship{background-color:#008300;border-color:#008300;color:#fff}.button.scholarship:hover{background-color:#00b850;border-color:#00b850}.button.scholarship.tag{background-color:#fff;color:#767676}.button.scholarship.tag.outline{border-color:#008300;text-decoration:none}.button.scholarship.tag:hover,.button.scholarship.tag.selected{background-color:#008300;border-color:#008300;color:#fff}.button.is-delete{color:#e23600;font-size:1rem;margin-top:2rem;padding:0;width:100%}.button.is-delete:hover{color:#fff}.button.is-delete .icon{padding:.25rem 0}@media(max-width: 768px){.button.is-delete{margin-top:0}}.card.entry-post.link.no-border{max-width:600px}.card.entry-post.link.no-border a .card-content.has-bottom-link{padding:0 0 3rem 0}.card.entry-post.link.no-border a:hover.has-background-tomato{background-color:#ff6933 !important}.card.entry-post.link.no-border a:hover.has-background-forest-green{background-color:#00b850 !important}.card-eyebrow{color:#333;font-family:"Roboto Condensed",sans-serif;font-size:1.43rem;font-weight:bold;text-transform:uppercase;line-height:1.3;letter-spacing:.02rem}.cases,.scholarships{padding-top:1.5rem;padding-bottom:1rem}.columns.submit{background-color:#f5f5f5;margin-bottom:0}.container>.navbar .navbar-brand{margin-left:0}@media(max-width: 650px){.case-holder{display:flex;flex-direction:column-reverse;gap:1rem}}.contribute{padding-top:2rem;padding-bottom:4rem}.contribute-card{float:right;max-width:380px;margin-right:1.9rem}@media(max-width: 1023px){.contribute-card{max-width:300px}}@media(max-width: 650px){.contribute-card{float:none;margin:0 2rem;max-width:unset}}.control.has-icons-left .icon{align-items:center;display:inline-flex;justify-content:center;color:#d8d8d8}.details,.faqs{padding-top:4rem;padding-bottom:2.5rem}.errorlist{color:#e23600;font-size:.9rem}.explore{padding-top:4rem;padding-bottom:2rem}.explore .container,.contribute .container,.cases .container,.scholarships .container,.details .container,.faqs .container{padding-left:2rem;padding-right:2rem}.faq__content{border-bottom:2px solid #d8d8d8;margin-bottom:1.5rem;padding-bottom:.75rem}.faq__head{display:flex;flex-direction:row;justify-content:space-between}.faq__head::after{font-family:"Vocabulary Icons";font-size:1.5rem;content:"";color:#333;margin:0 1rem}.faq__head.expanded::after{content:""}.faq__body{padding-right:1.5rem}.faq__body ul{list-style-type:disc;list-style-position:inside;margin-left:15px}.form.case,.form.scholarship{margin:1.5rem 2rem}.form.case .field,.form.scholarship .field{margin-bottom:1.5rem}.form.case .input,.form.case .select,.form.scholarship .input,.form.scholarship .select{margin-top:.5rem}.form.case h4,.form.scholarship h4{margin-bottom:.5rem}.form.case hr,.form.scholarship hr{margin:1rem 0;background-color:#d8d8d8}.hero{background-color:#f5f5f5;padding-top:4rem;padding-bottom:4rem}.hero.case,.hero.scholarship,.hero.faq{padding-top:2.5rem}.hero.case{box-shadow:inset 0px 6px 0px #e23600}.hero.scholarship{box-shadow:inset 0px 6px 0px #008300}.hero.submit{background-color:#fff;padding-top:1.5rem;padding-bottom:1.5rem}.hero-title,.hero-description,.hero .breadcrumb{padding:0 2rem}.hero-description.body-big{max-width:708px;padding-top:.5rem}.hero-description.body-normal,.card.blog-entry .blog-content .hero-description.blog-author,.card.blog-entry .blog-content .hero-description.excerpt,.hero-description.table,.hero-description.sidebar-menu,.hero-description.table-of-contents,.table-of-progress .step .hero-description.link{max-width:800px}.links-list{list-style-type:circle;overflow-wrap:break-word}.links-list a{color:#3c5c99}.required{color:darkred;font-weight:bold}.search-input{width:100%}.tags-filter{color:#3c5c99;cursor:pointer;user-select:none}.tags-filter #tags-hide,.tags-filter #tags-show{white-space:nowrap;gap:.25rem}.navbar .navbar-burger{height:40px}
+@charset "UTF-8";
+/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
+html,
+body,
+p,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+legend,
+textarea,
+pre,
+iframe,
+hr,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: normal;
+}
+
+ul {
+  list-style: none;
+}
+
+button,
+input,
+select,
+textarea {
+  margin: 0;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
+
+img,
+video {
+  height: auto;
+  max-width: 100%;
+}
+
+iframe {
+  border: 0;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+td:not([align]),
+th:not([align]) {
+  text-align: inherit;
+}
+
+.has-background-tomato {
+  background-color: rgb(226, 54, 0);
+}
+
+.has-text-tomato,
+.has-color-tomato {
+  color: rgb(226, 54, 0);
+}
+
+.has-background-gold {
+  background-color: rgb(239, 190, 0);
+}
+
+.has-text-gold,
+.has-color-gold {
+  color: rgb(239, 190, 0);
+}
+
+.has-background-forest-green {
+  background-color: rgb(0, 131, 0);
+}
+
+.has-text-forest-green, .card.entry-post.project-index .card-content .site-link,
+.has-color-forest-green,
+.card.entry-post.project-index .card-content .site-link .icon {
+  color: rgb(0, 131, 0);
+}
+
+.has-background-dark-turquoise {
+  background-color: rgb(5, 181, 218);
+}
+
+.has-text-dark-turquoise,
+.has-color-dark-turquoise {
+  color: rgb(5, 181, 218);
+}
+
+.has-background-dark-slate-blue {
+  background-color: rgb(60, 92, 153);
+}
+
+.has-text-dark-slate-blue,
+.has-color-dark-slate-blue {
+  color: rgb(60, 92, 153);
+}
+
+.has-background-brighter-dark-slate-blue {
+  background-color: rgb(16, 102, 231);
+}
+
+.has-text-brighter-dark-slate-blue,
+.has-color-brighter-dark-slate-blue {
+  color: rgb(16, 102, 231);
+}
+
+.has-background-dark-slate-gray {
+  background-color: rgb(51, 51, 51);
+}
+
+.has-text-dark-slate-gray,
+.has-color-dark-slate-gray,
+.table-of-progress .step .link,
+.card.blog-entry .blog-content .excerpt {
+  color: rgb(51, 51, 51);
+}
+
+.padding-smaller {
+  padding: 0.25rem !important;
+}
+
+.padding-small {
+  padding: 0.5rem !important;
+}
+
+.padding-normal, .tabs-content.is-boxed {
+  padding: 1rem !important;
+}
+
+.padding-big, .table-of-contents {
+  padding: 1.5rem !important;
+}
+
+.padding-bigger {
+  padding: 2rem !important;
+}
+
+.padding-large {
+  padding: 2.5rem !important;
+}
+
+.padding-larger {
+  padding: 3rem !important;
+}
+
+.padding-xl {
+  padding: 4rem !important;
+}
+
+.padding-xxl {
+  padding: 6rem !important;
+}
+
+.margin-smaller {
+  margin: 0.25rem !important;
+}
+
+.margin-small {
+  margin: 0.5rem !important;
+}
+
+.margin-normal {
+  margin: 1rem !important;
+}
+
+.margin-big {
+  margin: 1.5rem !important;
+}
+
+.margin-bigger {
+  margin: 2rem !important;
+}
+
+.margin-large {
+  margin: 2.5rem !important;
+}
+
+.margin-larger {
+  margin: 3rem !important;
+}
+
+.margin-xl {
+  margin: 4rem !important;
+}
+
+.margin-xxl {
+  margin: 6rem !important;
+}
+
+.body-bigger {
+  line-height: 1.6;
+  font-size: 1.43rem;
+}
+
+.body-big {
+  line-height: 1.6;
+  font-size: 1.12rem;
+}
+
+.body-normal, .table-of-progress .step .link, .table-of-contents, .sidebar-menu, .table, .card.blog-entry .blog-content .excerpt, .card.blog-entry .blog-content .blog-author {
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.body-list {
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.caption, .image .image-title {
+  font-size: 0.8rem;
+}
+
+.value {
+  font-family: "Roboto Condensed", sans-serif;
+  font-size: 4.37rem;
+  font-weight: bold;
+  line-height: 1.3;
+  letter-spacing: 0.02em;
+}
+
+.monospace {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.875em;
+}
+
+h1, h2, h3, h4, h5, h6, .title {
+  color: rgb(51, 51, 51);
+  font-family: "Roboto Condensed", sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  line-height: 1.3;
+  letter-spacing: 0.02rem;
+}
+
+.b-header, .table-of-progress .step-header, .subtitle {
+  color: rgb(51, 51, 51);
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  line-height: 1.3;
+  letter-spacing: 0.02rem;
+}
+
+h1,
+.title.is-1,
+.subtitle.is-1 {
+  font-size: 3.56rem;
+}
+
+h2,
+.title.is-2,
+.subtitle.is-2 {
+  font-size: 2.25rem;
+}
+
+h3,
+.title.is-3,
+.subtitle.is-3 {
+  font-size: 1.75rem;
+}
+
+h4,
+.title.is-4,
+.subtitle.is-4 {
+  font-size: 1.43rem;
+}
+
+h5,
+.title.is-5,
+.subtitle.is-5 {
+  font-size: 1.25rem;
+}
+
+h6,
+.title.is-6,
+.subtitle.is-6 {
+  font-size: 1.15rem;
+}
+
+body {
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 1rem;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Bulma Utilities */
+@keyframes spinAround {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}
+.pagination-previous,
+.pagination-next,
+.pagination-link,
+.pagination-ellipsis, .breadcrumb, .tabs, .file, .button, .is-unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.navbar-link:not(.is-arrowless)::after, .select:not(.is-multiple):not(.is-loading)::after {
+  border: 3px solid transparent;
+  border-radius: 2px;
+  border-right: 0;
+  border-top: 0;
+  content: " ";
+  display: block;
+  height: 0.625em;
+  margin-top: -0.4375em;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: rotate(-45deg);
+  transform-origin: center;
+  width: 0.625em;
+}
+
+.content:not(:last-child), .level:not(:last-child), .pagination:not(:last-child), .breadcrumb:not(:last-child), .tabs:not(:last-child), .table-container:not(:last-child), .table:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.control.is-loading::after, .select.is-loading::after, .button.is-loading::after {
+  animation: spinAround 500ms infinite linear;
+  border: 2px solid rgb(245, 245, 245);
+  border-radius: 290486px;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  content: "";
+  display: block;
+  height: 1em;
+  position: relative;
+  width: 1em;
+}
+
+.image.is-square img,
+.image.is-square .has-ratio, .image.is-1by1 img,
+.image.is-1by1 .has-ratio, .image.is-5by4 img,
+.image.is-5by4 .has-ratio, .image.is-4by3 img,
+.image.is-4by3 .has-ratio, .image.is-3by2 img,
+.image.is-3by2 .has-ratio, .image.is-5by3 img,
+.image.is-5by3 .has-ratio, .image.is-16by9 img,
+.image.is-16by9 .has-ratio, .image.is-2by1 img,
+.image.is-2by1 .has-ratio, .image.is-3by1 img,
+.image.is-3by1 .has-ratio, .image.is-4by5 img,
+.image.is-4by5 .has-ratio, .image.is-3by4 img,
+.image.is-3by4 .has-ratio, .image.is-2by3 img,
+.image.is-2by3 .has-ratio, .image.is-3by5 img,
+.image.is-3by5 .has-ratio, .image.is-9by16 img,
+.image.is-9by16 .has-ratio, .image.is-1by2 img,
+.image.is-1by2 .has-ratio, .image.is-1by3 img,
+.image.is-1by3 .has-ratio, .is-overlay {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.pagination-previous,
+.pagination-next,
+.pagination-link,
+.pagination-ellipsis, .file-cta,
+.file-name, .select select, .textarea, .input, .button {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-shadow: none;
+  display: inline-flex;
+  font-size: 1rem;
+  height: 2.5em;
+  justify-content: flex-start;
+  line-height: 1.5;
+  padding-bottom: calc(0.5em - 1px);
+  padding-left: calc(0.75em - 1px);
+  padding-right: calc(0.75em - 1px);
+  padding-top: calc(0.5em - 1px);
+  position: relative;
+  vertical-align: top;
+}
+.pagination-previous:focus,
+.pagination-next:focus,
+.pagination-link:focus,
+.pagination-ellipsis:focus, .file-cta:focus,
+.file-name:focus, .select select:focus, .textarea:focus, .input:focus, .button:focus, .is-focused.pagination-previous,
+.is-focused.pagination-next,
+.is-focused.pagination-link,
+.is-focused.pagination-ellipsis, .is-focused.file-cta,
+.is-focused.file-name, .select select.is-focused, .is-focused.textarea, .is-focused.input, .is-focused.button, .pagination-previous:active,
+.pagination-next:active,
+.pagination-link:active,
+.pagination-ellipsis:active, .file-cta:active,
+.file-name:active, .select select:active, .textarea:active, .input:active, .button:active, .is-active.pagination-previous,
+.is-active.pagination-next,
+.is-active.pagination-link,
+.is-active.pagination-ellipsis, .table-of-progress .step :hover .number.pagination-previous,
+.table-of-progress .step :hover .number.pagination-next,
+.table-of-progress .step :hover .number.pagination-link,
+.table-of-progress .step :hover .number.pagination-ellipsis, .table-of-progress .step :hover .is-active.pagination-previous,
+.table-of-progress .step :hover .is-active.pagination-next,
+.table-of-progress .step :hover .is-active.pagination-link,
+.table-of-progress .step :hover .is-active.pagination-ellipsis, .is-active.file-cta, .table-of-progress .step :hover .file-cta.number, .table-of-progress .step :hover .file-cta.is-active,
+.is-active.file-name,
+.table-of-progress .step :hover .file-name.number,
+.table-of-progress .step :hover .file-name.is-active, .select select.is-active, .select .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select select.number, .select .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select select.is-active, .is-active.textarea, .table-of-progress .step :hover .textarea.number, .table-of-progress .step :hover .textarea.is-active, .is-active.input, .table-of-progress .step :hover .input.number, .table-of-progress .step :hover .input.is-active, .is-active.button, .table-of-progress .step :hover .button.number, .table-of-progress .step :hover .button.is-active {
+  outline: none;
+}
+[disabled].pagination-previous,
+[disabled].pagination-next,
+[disabled].pagination-link,
+[disabled].pagination-ellipsis, [disabled].file-cta,
+[disabled].file-name, .select select[disabled], [disabled].textarea, [disabled].input, [disabled].button, fieldset[disabled] .pagination-previous,
+fieldset[disabled] .pagination-next,
+fieldset[disabled] .pagination-link,
+fieldset[disabled] .pagination-ellipsis, fieldset[disabled] .file-cta,
+fieldset[disabled] .file-name, fieldset[disabled] .select select, .select fieldset[disabled] select, fieldset[disabled] .textarea, fieldset[disabled] .input, fieldset[disabled] .button {
+  cursor: not-allowed;
+}
+
+/* Bulma Helpers */
+.has-text-white, .image .bookmark-icon, .image .image-title {
+  color: rgb(255, 255, 255) !important;
+}
+
+a.has-text-white:hover, .image a.bookmark-icon:hover, .image a.image-title:hover, a.has-text-white:focus, .image a.bookmark-icon:focus, .image a.image-title:focus {
+  color: #e6e6e6 !important;
+}
+
+.has-background-white {
+  background-color: rgb(255, 255, 255) !important;
+}
+
+.has-text-black, .image .image-icons {
+  color: rgb(0, 0, 0) !important;
+}
+
+a.has-text-black:hover, .image a.image-icons:hover, a.has-text-black:focus, .image a.image-icons:focus {
+  color: black !important;
+}
+
+.has-background-black, .image .bookmark-icon, .image .image-title {
+  background-color: rgb(0, 0, 0) !important;
+}
+
+.has-text-light {
+  color: hsl(0, 0%, 96%) !important;
+}
+
+a.has-text-light:hover, a.has-text-light:focus {
+  color: #dbdbdb !important;
+}
+
+.has-background-light {
+  background-color: hsl(0, 0%, 96%) !important;
+}
+
+.has-text-dark {
+  color: hsl(0, 0%, 21%) !important;
+}
+
+a.has-text-dark:hover, a.has-text-dark:focus {
+  color: #1c1c1c !important;
+}
+
+.has-background-dark {
+  background-color: hsl(0, 0%, 21%) !important;
+}
+
+.has-text-primary {
+  color: rgb(226, 54, 0) !important;
+}
+
+a.has-text-primary:hover, a.has-text-primary:focus {
+  color: #af2a00 !important;
+}
+
+.has-background-primary {
+  background-color: rgb(226, 54, 0) !important;
+}
+
+.has-text-primary-light {
+  color: #ffefeb !important;
+}
+
+a.has-text-primary-light:hover, a.has-text-primary-light:focus {
+  color: #ffc9b8 !important;
+}
+
+.has-background-primary-light {
+  background-color: #ffefeb !important;
+}
+
+.has-text-primary-dark {
+  color: #eb3800 !important;
+}
+
+a.has-text-primary-dark:hover, a.has-text-primary-dark:focus {
+  color: #ff541f !important;
+}
+
+.has-background-primary-dark {
+  background-color: #eb3800 !important;
+}
+
+.has-text-link {
+  color: rgb(226, 54, 0) !important;
+}
+
+a.has-text-link:hover, a.has-text-link:focus {
+  color: #af2a00 !important;
+}
+
+.has-background-link {
+  background-color: rgb(226, 54, 0) !important;
+}
+
+.has-text-link-light {
+  color: #ffefeb !important;
+}
+
+a.has-text-link-light:hover, a.has-text-link-light:focus {
+  color: #ffc9b8 !important;
+}
+
+.has-background-link-light {
+  background-color: #ffefeb !important;
+}
+
+.has-text-link-dark {
+  color: #eb3800 !important;
+}
+
+a.has-text-link-dark:hover, a.has-text-link-dark:focus {
+  color: #ff541f !important;
+}
+
+.has-background-link-dark {
+  background-color: #eb3800 !important;
+}
+
+.has-text-info {
+  color: rgb(25, 80, 184) !important;
+}
+
+a.has-text-info:hover, a.has-text-info:focus {
+  color: #133c8b !important;
+}
+
+.has-background-info {
+  background-color: rgb(25, 80, 184) !important;
+}
+
+.has-text-info-light {
+  color: rgb(209, 220, 241) !important;
+}
+
+a.has-text-info-light:hover, a.has-text-info-light:focus {
+  color: #aabee5 !important;
+}
+
+.has-background-info-light {
+  background-color: rgb(209, 220, 241) !important;
+}
+
+.has-text-info-dark {
+  color: rgb(25, 80, 184) !important;
+}
+
+a.has-text-info-dark:hover, a.has-text-info-dark:focus {
+  color: #2365e1 !important;
+}
+
+.has-background-info-dark {
+  background-color: rgb(25, 80, 184) !important;
+}
+
+.has-text-success {
+  color: rgb(0, 131, 0) !important;
+}
+
+a.has-text-success:hover, a.has-text-success:focus {
+  color: #005000 !important;
+}
+
+.has-background-success {
+  background-color: rgb(0, 131, 0) !important;
+}
+
+.has-text-success-light {
+  color: rgb(224, 242, 191) !important;
+}
+
+a.has-text-success-light:hover, a.has-text-success-light:focus {
+  color: #cbe995 !important;
+}
+
+.has-background-success-light {
+  background-color: rgb(224, 242, 191) !important;
+}
+
+.has-text-success-dark {
+  color: rgb(0, 131, 0) !important;
+}
+
+a.has-text-success-dark:hover, a.has-text-success-dark:focus {
+  color: #00b600 !important;
+}
+
+.has-background-success-dark {
+  background-color: rgb(0, 131, 0) !important;
+}
+
+.has-text-warning {
+  color: rgb(242, 171, 32) !important;
+}
+
+a.has-text-warning:hover, a.has-text-warning:focus {
+  color: #d3900c !important;
+}
+
+.has-background-warning {
+  background-color: rgb(242, 171, 32) !important;
+}
+
+.has-text-warning-light {
+  color: rgb(250, 236, 188) !important;
+}
+
+a.has-text-warning-light:hover, a.has-text-warning-light:focus {
+  color: #f6df8d !important;
+}
+
+.has-background-warning-light {
+  background-color: rgb(250, 236, 188) !important;
+}
+
+.has-text-warning-dark {
+  color: rgb(242, 171, 32) !important;
+}
+
+a.has-text-warning-dark:hover, a.has-text-warning-dark:focus {
+  color: #f5bd50 !important;
+}
+
+.has-background-warning-dark {
+  background-color: rgb(242, 171, 32) !important;
+}
+
+.has-text-danger {
+  color: rgb(200, 59, 30) !important;
+}
+
+a.has-text-danger:hover, a.has-text-danger:focus {
+  color: #9c2e17 !important;
+}
+
+.has-background-danger {
+  background-color: rgb(200, 59, 30) !important;
+}
+
+.has-text-danger-light {
+  color: rgb(255, 201, 201) !important;
+}
+
+a.has-text-danger-light:hover, a.has-text-danger-light:focus {
+  color: #ff9696 !important;
+}
+
+.has-background-danger-light {
+  background-color: rgb(255, 201, 201) !important;
+}
+
+.has-text-danger-dark {
+  color: rgb(200, 59, 30) !important;
+}
+
+a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
+  color: #e15538 !important;
+}
+
+.has-background-danger-dark {
+  background-color: rgb(200, 59, 30) !important;
+}
+
+.has-text-black-bis {
+  color: hsl(0, 0%, 7%) !important;
+}
+
+.has-background-black-bis {
+  background-color: hsl(0, 0%, 7%) !important;
+}
+
+.has-text-black-ter {
+  color: hsl(0, 0%, 14%) !important;
+}
+
+.has-background-black-ter {
+  background-color: hsl(0, 0%, 14%) !important;
+}
+
+.has-text-grey-darker {
+  color: hsl(0, 0%, 21%) !important;
+}
+
+.has-background-grey-darker {
+  background-color: hsl(0, 0%, 21%) !important;
+}
+
+.has-text-grey-dark {
+  color: rgb(118, 118, 118) !important;
+}
+
+.has-background-grey-dark {
+  background-color: rgb(118, 118, 118) !important;
+}
+
+.has-text-grey, .table-of-contents .icon, .sidebar-menu .icon {
+  color: rgb(176, 176, 176) !important;
+}
+
+.has-background-grey {
+  background-color: rgb(176, 176, 176) !important;
+}
+
+.has-text-grey-light {
+  color: rgb(216, 216, 216) !important;
+}
+
+.has-background-grey-light {
+  background-color: rgb(216, 216, 216) !important;
+}
+
+.has-text-grey-lighter {
+  color: rgb(245, 245, 245) !important;
+}
+
+.has-background-grey-lighter {
+  background-color: rgb(245, 245, 245) !important;
+}
+
+.has-text-white-ter {
+  color: hsl(0, 0%, 96%) !important;
+}
+
+.has-background-white-ter {
+  background-color: hsl(0, 0%, 96%) !important;
+}
+
+.has-text-white-bis {
+  color: hsl(0, 0%, 98%) !important;
+}
+
+.has-background-white-bis {
+  background-color: hsl(0, 0%, 98%) !important;
+}
+
+.is-flex-direction-row {
+  flex-direction: row !important;
+}
+
+.is-flex-direction-row-reverse {
+  flex-direction: row-reverse !important;
+}
+
+.is-flex-direction-column {
+  flex-direction: column !important;
+}
+
+.is-flex-direction-column-reverse {
+  flex-direction: column-reverse !important;
+}
+
+.is-flex-wrap-nowrap {
+  flex-wrap: nowrap !important;
+}
+
+.is-flex-wrap-wrap {
+  flex-wrap: wrap !important;
+}
+
+.is-flex-wrap-wrap-reverse {
+  flex-wrap: wrap-reverse !important;
+}
+
+.is-justify-content-flex-start {
+  justify-content: flex-start !important;
+}
+
+.is-justify-content-flex-end {
+  justify-content: flex-end !important;
+}
+
+.is-justify-content-center {
+  justify-content: center !important;
+}
+
+.is-justify-content-space-between {
+  justify-content: space-between !important;
+}
+
+.is-justify-content-space-around {
+  justify-content: space-around !important;
+}
+
+.is-justify-content-space-evenly {
+  justify-content: space-evenly !important;
+}
+
+.is-justify-content-start {
+  justify-content: start !important;
+}
+
+.is-justify-content-end {
+  justify-content: end !important;
+}
+
+.is-justify-content-left {
+  justify-content: left !important;
+}
+
+.is-justify-content-right {
+  justify-content: right !important;
+}
+
+.is-align-content-flex-start {
+  align-content: flex-start !important;
+}
+
+.is-align-content-flex-end {
+  align-content: flex-end !important;
+}
+
+.is-align-content-center {
+  align-content: center !important;
+}
+
+.is-align-content-space-between {
+  align-content: space-between !important;
+}
+
+.is-align-content-space-around {
+  align-content: space-around !important;
+}
+
+.is-align-content-space-evenly {
+  align-content: space-evenly !important;
+}
+
+.is-align-content-stretch {
+  align-content: stretch !important;
+}
+
+.is-align-content-start {
+  align-content: start !important;
+}
+
+.is-align-content-end {
+  align-content: end !important;
+}
+
+.is-align-content-baseline {
+  align-content: baseline !important;
+}
+
+.is-align-items-stretch {
+  align-items: stretch !important;
+}
+
+.is-align-items-flex-start {
+  align-items: flex-start !important;
+}
+
+.is-align-items-flex-end {
+  align-items: flex-end !important;
+}
+
+.is-align-items-center {
+  align-items: center !important;
+}
+
+.is-align-items-baseline {
+  align-items: baseline !important;
+}
+
+.is-align-items-start {
+  align-items: start !important;
+}
+
+.is-align-items-end {
+  align-items: end !important;
+}
+
+.is-align-items-self-start {
+  align-items: self-start !important;
+}
+
+.is-align-items-self-end {
+  align-items: self-end !important;
+}
+
+.is-align-self-auto {
+  align-self: auto !important;
+}
+
+.is-align-self-flex-start {
+  align-self: flex-start !important;
+}
+
+.is-align-self-flex-end {
+  align-self: flex-end !important;
+}
+
+.is-align-self-center {
+  align-self: center !important;
+}
+
+.is-align-self-baseline {
+  align-self: baseline !important;
+}
+
+.is-align-self-stretch {
+  align-self: stretch !important;
+}
+
+.is-flex-grow-0 {
+  flex-grow: 0 !important;
+}
+
+.is-flex-grow-1 {
+  flex-grow: 1 !important;
+}
+
+.is-flex-grow-2 {
+  flex-grow: 2 !important;
+}
+
+.is-flex-grow-3 {
+  flex-grow: 3 !important;
+}
+
+.is-flex-grow-4 {
+  flex-grow: 4 !important;
+}
+
+.is-flex-grow-5 {
+  flex-grow: 5 !important;
+}
+
+.is-flex-shrink-0 {
+  flex-shrink: 0 !important;
+}
+
+.is-flex-shrink-1 {
+  flex-shrink: 1 !important;
+}
+
+.is-flex-shrink-2 {
+  flex-shrink: 2 !important;
+}
+
+.is-flex-shrink-3 {
+  flex-shrink: 3 !important;
+}
+
+.is-flex-shrink-4 {
+  flex-shrink: 4 !important;
+}
+
+.is-flex-shrink-5 {
+  flex-shrink: 5 !important;
+}
+
+.is-clearfix::after {
+  clear: both;
+  content: " ";
+  display: table;
+}
+
+.is-pulled-left {
+  float: left !important;
+}
+
+.is-pulled-right {
+  float: right !important;
+}
+
+.is-radiusless {
+  border-radius: 0 !important;
+}
+
+.is-shadowless {
+  box-shadow: none !important;
+}
+
+.is-clickable {
+  cursor: pointer !important;
+}
+
+.is-clipped {
+  overflow: hidden !important;
+}
+
+.is-relative {
+  position: relative !important;
+}
+
+.is-marginless {
+  margin: 0 !important;
+}
+
+.is-paddingless, .image.is-compact .image-icons, .sidebar-menu .menu-list .link, .card.entry-post.project-index .card-content .content, .button.is-text {
+  padding: 0 !important;
+}
+
+.margin--0 {
+  margin: 0 !important;
+}
+
+.margin-top-0 {
+  margin-top: 0 !important;
+}
+
+.margin-right-0 {
+  margin-right: 0 !important;
+}
+
+.margin-bottom-0 {
+  margin-bottom: 0 !important;
+}
+
+.margin-left-0 {
+  margin-left: 0 !important;
+}
+
+.margin-horizontal-0 {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.margin-vertical-0 {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.margin--smaller {
+  margin: 0.25rem !important;
+}
+
+.margin-top-smaller {
+  margin-top: 0.25rem !important;
+}
+
+.margin-right-smaller {
+  margin-right: 0.25rem !important;
+}
+
+.margin-bottom-smaller {
+  margin-bottom: 0.25rem !important;
+}
+
+.margin-left-smaller {
+  margin-left: 0.25rem !important;
+}
+
+.margin-horizontal-smaller {
+  margin-left: 0.25rem !important;
+  margin-right: 0.25rem !important;
+}
+
+.margin-vertical-smaller {
+  margin-top: 0.25rem !important;
+  margin-bottom: 0.25rem !important;
+}
+
+.margin--small {
+  margin: 0.5rem !important;
+}
+
+.margin-top-small, .card.blog-entry .blog-content .blog-author, .card.entry-post.project-index .card-content .site-link {
+  margin-top: 0.5rem !important;
+}
+
+.margin-right-small, .card.entry-post.project-index .card-content .labels .button {
+  margin-right: 0.5rem !important;
+}
+
+.margin-bottom-small, .sidebar-menu .divider, .card.entry-post.project-index .card-content .external-links .button {
+  margin-bottom: 0.5rem !important;
+}
+
+.margin-left-small {
+  margin-left: 0.5rem !important;
+}
+
+.margin-horizontal-small {
+  margin-left: 0.5rem !important;
+  margin-right: 0.5rem !important;
+}
+
+.margin-vertical-small {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+.margin--normal {
+  margin: 1rem !important;
+}
+
+.margin-top-normal, .table-of-contents, .sidebar-menu .divider, .card.blog-entry .blog-content .excerpt, .card.entry-post.project-index .card-content .labels {
+  margin-top: 1rem !important;
+}
+
+.margin-right-normal {
+  margin-right: 1rem !important;
+}
+
+.margin-bottom-normal, .card.entry-post.project-index .card-content .labels .button, .card.entry-post.project-index .card-content .labels {
+  margin-bottom: 1rem !important;
+}
+
+.margin-left-normal, .table-of-progress .step .name {
+  margin-left: 1rem !important;
+}
+
+.margin-horizontal-normal {
+  margin-left: 1rem !important;
+  margin-right: 1rem !important;
+}
+
+.margin-vertical-normal {
+  margin-top: 1rem !important;
+  margin-bottom: 1rem !important;
+}
+
+.margin--big {
+  margin: 1.5rem !important;
+}
+
+.margin-top-big {
+  margin-top: 1.5rem !important;
+}
+
+.margin-right-big {
+  margin-right: 1.5rem !important;
+}
+
+.margin-bottom-big, .table-of-progress .step-header {
+  margin-bottom: 1.5rem !important;
+}
+
+.margin-left-big {
+  margin-left: 1.5rem !important;
+}
+
+.margin-horizontal-big {
+  margin-left: 1.5rem !important;
+  margin-right: 1.5rem !important;
+}
+
+.margin-vertical-big {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+
+.margin--bigger {
+  margin: 2rem !important;
+}
+
+.margin-top-bigger, .card.entry-post.project-index .card-content .content {
+  margin-top: 2rem !important;
+}
+
+.margin-right-bigger {
+  margin-right: 2rem !important;
+}
+
+.margin-bottom-bigger {
+  margin-bottom: 2rem !important;
+}
+
+.margin-left-bigger, .card.blog-entry .blog-content {
+  margin-left: 2rem !important;
+}
+
+.margin-horizontal-bigger {
+  margin-left: 2rem !important;
+  margin-right: 2rem !important;
+}
+
+.margin-vertical-bigger {
+  margin-top: 2rem !important;
+  margin-bottom: 2rem !important;
+}
+
+.margin--large {
+  margin: 2.5rem !important;
+}
+
+.margin-top-large {
+  margin-top: 2.5rem !important;
+}
+
+.margin-right-large {
+  margin-right: 2.5rem !important;
+}
+
+.margin-bottom-large {
+  margin-bottom: 2.5rem !important;
+}
+
+.margin-left-large {
+  margin-left: 2.5rem !important;
+}
+
+.margin-horizontal-large {
+  margin-left: 2.5rem !important;
+  margin-right: 2.5rem !important;
+}
+
+.margin-vertical-large {
+  margin-top: 2.5rem !important;
+  margin-bottom: 2.5rem !important;
+}
+
+.margin--larger {
+  margin: 3rem !important;
+}
+
+.margin-top-larger {
+  margin-top: 3rem !important;
+}
+
+.margin-right-larger {
+  margin-right: 3rem !important;
+}
+
+.margin-bottom-larger {
+  margin-bottom: 3rem !important;
+}
+
+.margin-left-larger {
+  margin-left: 3rem !important;
+}
+
+.margin-horizontal-larger {
+  margin-left: 3rem !important;
+  margin-right: 3rem !important;
+}
+
+.margin-vertical-larger {
+  margin-top: 3rem !important;
+  margin-bottom: 3rem !important;
+}
+
+.margin--xl {
+  margin: 4rem !important;
+}
+
+.margin-top-xl {
+  margin-top: 4rem !important;
+}
+
+.margin-right-xl {
+  margin-right: 4rem !important;
+}
+
+.margin-bottom-xl {
+  margin-bottom: 4rem !important;
+}
+
+.margin-left-xl {
+  margin-left: 4rem !important;
+}
+
+.margin-horizontal-xl {
+  margin-left: 4rem !important;
+  margin-right: 4rem !important;
+}
+
+.margin-vertical-xl {
+  margin-top: 4rem !important;
+  margin-bottom: 4rem !important;
+}
+
+.margin--xxl {
+  margin: 6rem !important;
+}
+
+.margin-top-xxl {
+  margin-top: 6rem !important;
+}
+
+.margin-right-xxl {
+  margin-right: 6rem !important;
+}
+
+.margin-bottom-xxl {
+  margin-bottom: 6rem !important;
+}
+
+.margin-left-xxl {
+  margin-left: 6rem !important;
+}
+
+.margin-horizontal-xxl {
+  margin-left: 6rem !important;
+  margin-right: 6rem !important;
+}
+
+.margin-vertical-xxl {
+  margin-top: 6rem !important;
+  margin-bottom: 6rem !important;
+}
+
+.padding--0 {
+  padding: 0 !important;
+}
+
+.padding-top-0 {
+  padding-top: 0 !important;
+}
+
+.padding-right-0 {
+  padding-right: 0 !important;
+}
+
+.padding-bottom-0 {
+  padding-bottom: 0 !important;
+}
+
+.padding-left-0 {
+  padding-left: 0 !important;
+}
+
+.padding-horizontal-0 {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.padding-vertical-0 {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.padding--smaller {
+  padding: 0.25rem !important;
+}
+
+.padding-top-smaller {
+  padding-top: 0.25rem !important;
+}
+
+.padding-right-smaller {
+  padding-right: 0.25rem !important;
+}
+
+.padding-bottom-smaller {
+  padding-bottom: 0.25rem !important;
+}
+
+.padding-left-smaller {
+  padding-left: 0.25rem !important;
+}
+
+.padding-horizontal-smaller, .navbar.is-compact .navbar-end > .navbar-item {
+  padding-left: 0.25rem !important;
+  padding-right: 0.25rem !important;
+}
+
+.padding-vertical-smaller, .table-of-progress .step .number, .table-of-progress .step .is-active, .table-of-progress .step :hover .number, .table-of-progress .step :hover .is-active, .card.entry-post.project-index .card-content .external-links .button .icon, .card.entry-post.project-index .card-content .site-link .icon {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+.padding--small {
+  padding: 0.5rem !important;
+}
+
+.padding-top-small, .sidebar-menu .menu-list .link {
+  padding-top: 0.5rem !important;
+}
+
+.padding-right-small, .table-of-contents .icon, .sidebar-menu .icon {
+  padding-right: 0.5rem !important;
+}
+
+.padding-bottom-small {
+  padding-bottom: 0.5rem !important;
+}
+
+.padding-left-small {
+  padding-left: 0.5rem !important;
+}
+
+.padding-horizontal-small, .image.is-compact .image-icons, .image .bookmark-icon, .card.entry-post.project-index .card-content .external-links .button .link-content, .card.entry-post.project-index .card-content .site-link .icon {
+  padding-left: 0.5rem !important;
+  padding-right: 0.5rem !important;
+}
+
+.padding-vertical-small, .image .image-title,
+.image .image-icons,
+.image .bookmark-icon, .tabs.is-boxed a {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+.padding--normal {
+  padding: 1rem !important;
+}
+
+.padding-top-normal, .sidebar-menu {
+  padding-top: 1rem !important;
+}
+
+.padding-right-normal {
+  padding-right: 1rem !important;
+}
+
+.padding-bottom-normal {
+  padding-bottom: 1rem !important;
+}
+
+.padding-left-normal {
+  padding-left: 1rem !important;
+}
+
+.padding-horizontal-normal, .image .image-icons, .image .image-title, .tabs.is-boxed a {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+.padding-vertical-normal, .navbar.is-compact, .notification.is-compact .notification-container {
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
+}
+
+.padding--big {
+  padding: 1.5rem !important;
+}
+
+.padding-top-big {
+  padding-top: 1.5rem !important;
+}
+
+.padding-right-big {
+  padding-right: 1.5rem !important;
+}
+
+.padding-bottom-big, .sidebar-menu {
+  padding-bottom: 1.5rem !important;
+}
+
+.padding-left-big {
+  padding-left: 1.5rem !important;
+}
+
+.padding-horizontal-big, .sidebar-menu .menu-list .link {
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important;
+}
+
+.padding-vertical-big {
+  padding-top: 1.5rem !important;
+  padding-bottom: 1.5rem !important;
+}
+
+.padding--bigger {
+  padding: 2rem !important;
+}
+
+.padding-top-bigger {
+  padding-top: 2rem !important;
+}
+
+.padding-right-bigger {
+  padding-right: 2rem !important;
+}
+
+.padding-bottom-bigger {
+  padding-bottom: 2rem !important;
+}
+
+.padding-left-bigger {
+  padding-left: 2rem !important;
+}
+
+.padding-horizontal-bigger, .navbar.is-compact {
+  padding-left: 2rem !important;
+  padding-right: 2rem !important;
+}
+
+.padding-vertical-bigger {
+  padding-top: 2rem !important;
+  padding-bottom: 2rem !important;
+}
+
+.padding--large {
+  padding: 2.5rem !important;
+}
+
+.padding-top-large {
+  padding-top: 2.5rem !important;
+}
+
+.padding-right-large {
+  padding-right: 2.5rem !important;
+}
+
+.padding-bottom-large {
+  padding-bottom: 2.5rem !important;
+}
+
+.padding-left-large {
+  padding-left: 2.5rem !important;
+}
+
+.padding-horizontal-large {
+  padding-left: 2.5rem !important;
+  padding-right: 2.5rem !important;
+}
+
+.padding-vertical-large {
+  padding-top: 2.5rem !important;
+  padding-bottom: 2.5rem !important;
+}
+
+.padding--larger {
+  padding: 3rem !important;
+}
+
+.padding-top-larger {
+  padding-top: 3rem !important;
+}
+
+.padding-right-larger {
+  padding-right: 3rem !important;
+}
+
+.padding-bottom-larger {
+  padding-bottom: 3rem !important;
+}
+
+.padding-left-larger {
+  padding-left: 3rem !important;
+}
+
+.padding-horizontal-larger {
+  padding-left: 3rem !important;
+  padding-right: 3rem !important;
+}
+
+.padding-vertical-larger {
+  padding-top: 3rem !important;
+  padding-bottom: 3rem !important;
+}
+
+.padding--xl {
+  padding: 4rem !important;
+}
+
+.padding-top-xl {
+  padding-top: 4rem !important;
+}
+
+.padding-right-xl {
+  padding-right: 4rem !important;
+}
+
+.padding-bottom-xl {
+  padding-bottom: 4rem !important;
+}
+
+.padding-left-xl {
+  padding-left: 4rem !important;
+}
+
+.padding-horizontal-xl {
+  padding-left: 4rem !important;
+  padding-right: 4rem !important;
+}
+
+.padding-vertical-xl {
+  padding-top: 4rem !important;
+  padding-bottom: 4rem !important;
+}
+
+.padding--xxl {
+  padding: 6rem !important;
+}
+
+.padding-top-xxl {
+  padding-top: 6rem !important;
+}
+
+.padding-right-xxl {
+  padding-right: 6rem !important;
+}
+
+.padding-bottom-xxl {
+  padding-bottom: 6rem !important;
+}
+
+.padding-left-xxl {
+  padding-left: 6rem !important;
+}
+
+.padding-horizontal-xxl {
+  padding-left: 6rem !important;
+  padding-right: 6rem !important;
+}
+
+.padding-vertical-xxl {
+  padding-top: 6rem !important;
+  padding-bottom: 6rem !important;
+}
+
+.is-size-1 {
+  font-size: 3.56rem !important;
+}
+
+.is-size-2 {
+  font-size: 2.25rem !important;
+}
+
+.is-size-3 {
+  font-size: 1.75rem !important;
+}
+
+.is-size-4 {
+  font-size: 1.43rem !important;
+}
+
+.is-size-5 {
+  font-size: 1.12rem !important;
+}
+
+.is-size-6 {
+  font-size: 1rem !important;
+}
+
+.is-size-7 {
+  font-size: 0.8rem !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-size-1-mobile {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-mobile {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-mobile {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-mobile {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-mobile {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-mobile {
+    font-size: 1rem !important;
+  }
+  .is-size-7-mobile {
+    font-size: 0.8rem !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-size-1-tablet {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-tablet {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-tablet {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-tablet {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-tablet {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-tablet {
+    font-size: 1rem !important;
+  }
+  .is-size-7-tablet {
+    font-size: 0.8rem !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-size-1-touch {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-touch {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-touch {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-touch {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-touch {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-touch {
+    font-size: 1rem !important;
+  }
+  .is-size-7-touch {
+    font-size: 0.8rem !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-size-1-desktop {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-desktop {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-desktop {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-desktop {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-desktop {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-desktop {
+    font-size: 1rem !important;
+  }
+  .is-size-7-desktop {
+    font-size: 0.8rem !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-size-1-widescreen {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-widescreen {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-widescreen {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-widescreen {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-widescreen {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-widescreen {
+    font-size: 1rem !important;
+  }
+  .is-size-7-widescreen {
+    font-size: 0.8rem !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-size-1-fullhd {
+    font-size: 3.56rem !important;
+  }
+  .is-size-2-fullhd {
+    font-size: 2.25rem !important;
+  }
+  .is-size-3-fullhd {
+    font-size: 1.75rem !important;
+  }
+  .is-size-4-fullhd {
+    font-size: 1.43rem !important;
+  }
+  .is-size-5-fullhd {
+    font-size: 1.12rem !important;
+  }
+  .is-size-6-fullhd {
+    font-size: 1rem !important;
+  }
+  .is-size-7-fullhd {
+    font-size: 0.8rem !important;
+  }
+}
+.has-text-centered, .table-of-progress .step .number, .table-of-progress .step .is-active, .table-of-progress .step :hover .number, .table-of-progress .step :hover .is-active {
+  text-align: center !important;
+}
+
+.has-text-justified {
+  text-align: justify !important;
+}
+
+.has-text-left {
+  text-align: left !important;
+}
+
+.has-text-right {
+  text-align: right !important;
+}
+
+@media screen and (max-width: 768px) {
+  .has-text-centered-mobile {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .has-text-centered-tablet {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-centered-tablet-only {
+    text-align: center !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .has-text-centered-touch {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .has-text-centered-desktop {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-centered-desktop-only {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .has-text-centered-widescreen {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-centered-widescreen-only {
+    text-align: center !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .has-text-centered-fullhd {
+    text-align: center !important;
+  }
+}
+@media screen and (max-width: 768px) {
+  .has-text-justified-mobile {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .has-text-justified-tablet {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-justified-tablet-only {
+    text-align: justify !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .has-text-justified-touch {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .has-text-justified-desktop {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-justified-desktop-only {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .has-text-justified-widescreen {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-justified-widescreen-only {
+    text-align: justify !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .has-text-justified-fullhd {
+    text-align: justify !important;
+  }
+}
+@media screen and (max-width: 768px) {
+  .has-text-left-mobile {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .has-text-left-tablet {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-left-tablet-only {
+    text-align: left !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .has-text-left-touch {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .has-text-left-desktop {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-left-desktop-only {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .has-text-left-widescreen {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-left-widescreen-only {
+    text-align: left !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .has-text-left-fullhd {
+    text-align: left !important;
+  }
+}
+@media screen and (max-width: 768px) {
+  .has-text-right-mobile {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .has-text-right-tablet {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-right-tablet-only {
+    text-align: right !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .has-text-right-touch {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .has-text-right-desktop {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-right-desktop-only {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .has-text-right-widescreen {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-right-widescreen-only {
+    text-align: right !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .has-text-right-fullhd {
+    text-align: right !important;
+  }
+}
+.is-capitalized {
+  text-transform: capitalize !important;
+}
+
+.is-lowercase {
+  text-transform: lowercase !important;
+}
+
+.is-uppercase {
+  text-transform: uppercase !important;
+}
+
+.is-italic {
+  font-style: italic !important;
+}
+
+.has-text-weight-light {
+  font-weight: 300 !important;
+}
+
+.has-text-weight-normal {
+  font-weight: 400 !important;
+}
+
+.has-text-weight-medium {
+  font-weight: 500 !important;
+}
+
+.has-text-weight-semibold {
+  font-weight: 600 !important;
+}
+
+.has-text-weight-bold {
+  font-weight: 700 !important;
+}
+
+.is-family-primary {
+  font-family: "Source Sans Pro", sans-serif !important;
+}
+
+.is-family-secondary {
+  font-family: "Roboto Condensed", sans-serif !important;
+}
+
+.is-family-sans-serif {
+  font-family: "Source Sans Pro", sans-serif !important;
+}
+
+.is-family-monospace {
+  font-family: "JetBrains Mono", monospace !important;
+}
+
+.is-family-code {
+  font-family: "JetBrains Mono", monospace !important;
+}
+
+.is-block {
+  display: block !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-block-mobile {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-block-tablet {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-block-tablet-only {
+    display: block !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-block-touch {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-block-desktop {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-block-desktop-only {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-block-widescreen {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-block-widescreen-only {
+    display: block !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-block-fullhd {
+    display: block !important;
+  }
+}
+.is-flex {
+  display: flex !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-flex-mobile {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-flex-tablet {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-flex-tablet-only {
+    display: flex !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-flex-touch {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-flex-desktop {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-flex-desktop-only {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-flex-widescreen {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-flex-widescreen-only {
+    display: flex !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-flex-fullhd {
+    display: flex !important;
+  }
+}
+.is-inline {
+  display: inline !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-mobile {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-inline-tablet {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-tablet-only {
+    display: inline !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-inline-touch {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-inline-desktop {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-desktop-only {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-inline-widescreen {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-widescreen-only {
+    display: inline !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-inline-fullhd {
+    display: inline !important;
+  }
+}
+.is-inline-block {
+  display: inline-block !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-block-mobile {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-inline-block-tablet {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-block-tablet-only {
+    display: inline-block !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-inline-block-touch {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-inline-block-desktop {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-block-desktop-only {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-inline-block-widescreen {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-block-widescreen-only {
+    display: inline-block !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-inline-block-fullhd {
+    display: inline-block !important;
+  }
+}
+.is-inline-flex {
+  display: inline-flex !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-flex-mobile {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-inline-flex-tablet {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-flex-tablet-only {
+    display: inline-flex !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-inline-flex-touch {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-inline-flex-desktop {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-flex-desktop-only {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-inline-flex-widescreen {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-flex-widescreen-only {
+    display: inline-flex !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-inline-flex-fullhd {
+    display: inline-flex !important;
+  }
+}
+.is-hidden {
+  display: none !important;
+}
+
+.is-sr-only {
+  border: none !important;
+  clip: rect(0, 0, 0, 0) !important;
+  height: 0.01em !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  white-space: nowrap !important;
+  width: 0.01em !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-hidden-mobile {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-hidden-tablet {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-hidden-tablet-only {
+    display: none !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-hidden-touch {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-hidden-desktop {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-hidden-desktop-only {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-hidden-widescreen {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-hidden-widescreen-only {
+    display: none !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-hidden-fullhd {
+    display: none !important;
+  }
+}
+.is-invisible {
+  visibility: hidden !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-invisible-mobile {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .is-invisible-tablet {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-invisible-tablet-only {
+    visibility: hidden !important;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .is-invisible-touch {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .is-invisible-desktop {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-invisible-desktop-only {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .is-invisible-widescreen {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-invisible-widescreen-only {
+    visibility: hidden !important;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .is-invisible-fullhd {
+    visibility: hidden !important;
+  }
+}
+html {
+  background-color: rgb(255, 255, 255);
+  font-size: 16px;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  min-width: 300px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+  text-size-adjust: 100%;
+}
+
+article,
+aside,
+figure,
+footer,
+header,
+hgroup,
+section {
+  display: block;
+}
+
+body,
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: "Source Sans Pro", sans-serif;
+}
+
+code,
+pre {
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: auto;
+  font-family: "JetBrains Mono", monospace;
+}
+
+body {
+  color: rgb(118, 118, 118);
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+a {
+  color: rgb(226, 54, 0);
+  cursor: pointer;
+  text-decoration: none;
+}
+a strong {
+  color: currentColor;
+}
+a:hover {
+  color: currentColor;
+}
+
+code {
+  background-color: hsl(0, 0%, 96%);
+  color: #962400;
+  font-size: 0.875em;
+  font-weight: normal;
+  padding: 0.25em 0.5em 0.25em;
+}
+
+hr {
+  background-color: hsl(0, 0%, 96%);
+  border: none;
+  display: block;
+  height: 2px;
+  margin: 1.5rem 0;
+}
+
+img {
+  height: auto;
+  max-width: 100%;
+}
+
+input[type=checkbox],
+input[type=radio] {
+  vertical-align: baseline;
+}
+
+small {
+  font-size: 0.875em;
+}
+
+span {
+  font-style: inherit;
+  font-weight: inherit;
+}
+
+strong {
+  color: hsl(0, 0%, 21%);
+  font-weight: 700;
+}
+
+fieldset {
+  border: none;
+}
+
+pre {
+  -webkit-overflow-scrolling: touch;
+  background-color: hsl(0, 0%, 96%);
+  color: rgb(118, 118, 118);
+  font-size: 0.875em;
+  overflow-x: auto;
+  padding: 1.25rem 1.5rem;
+  white-space: pre;
+  word-wrap: normal;
+}
+pre code {
+  background-color: transparent;
+  color: currentColor;
+  font-size: 1em;
+  padding: 0;
+}
+
+table td,
+table th {
+  vertical-align: top;
+}
+table td:not([align]),
+table th:not([align]) {
+  text-align: inherit;
+}
+table th {
+  color: hsl(0, 0%, 21%);
+}
+
+.button {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(245, 245, 245);
+  border-width: 1px;
+  color: hsl(0, 0%, 21%);
+  cursor: pointer;
+  font-family: "Roboto Condensed", sans-serif;
+  justify-content: center;
+  padding-bottom: calc(0.5em - 1px);
+  padding-left: 1em;
+  padding-right: 1em;
+  padding-top: calc(0.5em - 1px);
+  text-align: center;
+  white-space: nowrap;
+}
+.button strong {
+  color: inherit;
+}
+.button .icon, .button .icon.is-small, .button .icon.is-medium, .button .icon.is-large {
+  height: 1.5em;
+  width: 1.5em;
+}
+.button .icon:first-child:not(:last-child) {
+  margin-left: calc(-0.5em - 1px);
+  margin-right: 0.25em;
+}
+.button .icon:last-child:not(:first-child) {
+  margin-left: 0.25em;
+  margin-right: calc(-0.5em - 1px);
+}
+.button .icon:first-child:last-child {
+  margin-left: calc(-0.5em - 1px);
+  margin-right: calc(-0.5em - 1px);
+}
+.button:hover, .button.is-hovered {
+  border-color: rgb(216, 216, 216);
+  color: currentColor;
+}
+.button:focus, .button.is-focused {
+  border-color: rgb(60, 92, 153);
+  color: hsl(0, 0%, 21%);
+}
+.button:focus:not(:active), .button.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.button:active, .button.is-active, .table-of-progress .step :hover .button.number, .table-of-progress .step :hover .button.is-active {
+  border-color: rgb(118, 118, 118);
+  color: hsl(0, 0%, 21%);
+}
+.button.is-text {
+  background-color: transparent;
+  border-color: transparent;
+  color: rgb(118, 118, 118);
+  text-decoration: underline;
+}
+.button.is-text:hover, .button.is-text.is-hovered, .button.is-text:focus, .button.is-text.is-focused {
+  background-color: hsl(0, 0%, 96%);
+  color: hsl(0, 0%, 21%);
+}
+.button.is-text:active, .button.is-text.is-active, .table-of-progress .step :hover .button.is-text.number, .table-of-progress .step :hover .button.is-text.is-active {
+  background-color: #e8e8e8;
+  color: hsl(0, 0%, 21%);
+}
+.button.is-text[disabled], fieldset[disabled] .button.is-text {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-white {
+  background-color: rgb(255, 255, 255);
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.button.is-white:hover, .button.is-white.is-hovered {
+  background-color: #f9f9f9;
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.button.is-white:focus, .button.is-white.is-focused {
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.button.is-white:focus:not(:active), .button.is-white.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+.button.is-white:active, .button.is-white.is-active, .table-of-progress .step :hover .button.is-white.number, .table-of-progress .step :hover .button.is-white.is-active {
+  background-color: #f2f2f2;
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.button.is-white[disabled], fieldset[disabled] .button.is-white {
+  background-color: rgb(255, 255, 255);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-white.is-inverted {
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+}
+.button.is-white.is-inverted:hover, .button.is-white.is-inverted.is-hovered {
+  background-color: black;
+}
+.button.is-white.is-inverted[disabled], fieldset[disabled] .button.is-white.is-inverted {
+  background-color: rgb(0, 0, 0);
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(255, 255, 255);
+}
+.button.is-white.is-loading::after {
+  border-color: transparent transparent rgb(0, 0, 0) rgb(0, 0, 0) !important;
+}
+.button.is-white.is-outlined {
+  background-color: transparent;
+  border-color: rgb(255, 255, 255);
+  color: rgb(255, 255, 255);
+}
+.button.is-white.is-outlined:hover, .button.is-white.is-outlined.is-hovered, .button.is-white.is-outlined:focus, .button.is-white.is-outlined.is-focused {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}
+.button.is-white.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(255, 255, 255) rgb(255, 255, 255) !important;
+}
+.button.is-white.is-outlined.is-loading:hover::after, .button.is-white.is-outlined.is-loading.is-hovered::after, .button.is-white.is-outlined.is-loading:focus::after, .button.is-white.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(0, 0, 0) rgb(0, 0, 0) !important;
+}
+.button.is-white.is-outlined[disabled], fieldset[disabled] .button.is-white.is-outlined {
+  background-color: transparent;
+  border-color: rgb(255, 255, 255);
+  box-shadow: none;
+  color: rgb(255, 255, 255);
+}
+.button.is-white.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 0, 0);
+  color: rgb(0, 0, 0);
+}
+.button.is-white.is-inverted.is-outlined:hover, .button.is-white.is-inverted.is-outlined.is-hovered, .button.is-white.is-inverted.is-outlined:focus, .button.is-white.is-inverted.is-outlined.is-focused {
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+}
+.button.is-white.is-inverted.is-outlined.is-loading:hover::after, .button.is-white.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-white.is-inverted.is-outlined.is-loading:focus::after, .button.is-white.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(255, 255, 255) rgb(255, 255, 255) !important;
+}
+.button.is-white.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-white.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 0, 0);
+  box-shadow: none;
+  color: rgb(0, 0, 0);
+}
+.button.is-black {
+  background-color: rgb(0, 0, 0);
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.button.is-black:hover, .button.is-black.is-hovered {
+  background-color: black;
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.button.is-black:focus, .button.is-black.is-focused {
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.button.is-black:focus:not(:active), .button.is-black.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(0, 0, 0, 0.25);
+}
+.button.is-black:active, .button.is-black.is-active, .table-of-progress .step :hover .button.is-black.number, .table-of-progress .step :hover .button.is-black.is-active {
+  background-color: black;
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.button.is-black[disabled], fieldset[disabled] .button.is-black {
+  background-color: rgb(0, 0, 0);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-black.is-inverted {
+  background-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}
+.button.is-black.is-inverted:hover, .button.is-black.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-black.is-inverted[disabled], fieldset[disabled] .button.is-black.is-inverted {
+  background-color: rgb(255, 255, 255);
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(0, 0, 0);
+}
+.button.is-black.is-loading::after {
+  border-color: transparent transparent rgb(255, 255, 255) rgb(255, 255, 255) !important;
+}
+.button.is-black.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 0, 0);
+  color: rgb(0, 0, 0);
+}
+.button.is-black.is-outlined:hover, .button.is-black.is-outlined.is-hovered, .button.is-black.is-outlined:focus, .button.is-black.is-outlined.is-focused {
+  background-color: rgb(0, 0, 0);
+  border-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+}
+.button.is-black.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(0, 0, 0) rgb(0, 0, 0) !important;
+}
+.button.is-black.is-outlined.is-loading:hover::after, .button.is-black.is-outlined.is-loading.is-hovered::after, .button.is-black.is-outlined.is-loading:focus::after, .button.is-black.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(255, 255, 255) rgb(255, 255, 255) !important;
+}
+.button.is-black.is-outlined[disabled], fieldset[disabled] .button.is-black.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 0, 0);
+  box-shadow: none;
+  color: rgb(0, 0, 0);
+}
+.button.is-black.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgb(255, 255, 255);
+  color: rgb(255, 255, 255);
+}
+.button.is-black.is-inverted.is-outlined:hover, .button.is-black.is-inverted.is-outlined.is-hovered, .button.is-black.is-inverted.is-outlined:focus, .button.is-black.is-inverted.is-outlined.is-focused {
+  background-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}
+.button.is-black.is-inverted.is-outlined.is-loading:hover::after, .button.is-black.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-black.is-inverted.is-outlined.is-loading:focus::after, .button.is-black.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(0, 0, 0) rgb(0, 0, 0) !important;
+}
+.button.is-black.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-black.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgb(255, 255, 255);
+  box-shadow: none;
+  color: rgb(255, 255, 255);
+}
+.button.is-light {
+  background-color: hsl(0, 0%, 96%);
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light:hover, .button.is-light.is-hovered {
+  background-color: #eeeeee;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light:focus, .button.is-light.is-focused {
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light:focus:not(:active), .button.is-light.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+.button.is-light:active, .button.is-light.is-active, .table-of-progress .step :hover .button.is-light.number, .table-of-progress .step :hover .button.is-light.is-active {
+  background-color: #e8e8e8;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light[disabled], fieldset[disabled] .button.is-light {
+  background-color: hsl(0, 0%, 96%);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-light.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: hsl(0, 0%, 96%);
+}
+.button.is-light.is-inverted:hover, .button.is-light.is-inverted.is-hovered {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light.is-inverted[disabled], fieldset[disabled] .button.is-light.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: transparent;
+  box-shadow: none;
+  color: hsl(0, 0%, 96%);
+}
+.button.is-light.is-loading::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+.button.is-light.is-outlined {
+  background-color: transparent;
+  border-color: hsl(0, 0%, 96%);
+  color: hsl(0, 0%, 96%);
+}
+.button.is-light.is-outlined:hover, .button.is-light.is-outlined.is-hovered, .button.is-light.is-outlined:focus, .button.is-light.is-outlined.is-focused {
+  background-color: hsl(0, 0%, 96%);
+  border-color: hsl(0, 0%, 96%);
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light.is-outlined.is-loading::after {
+  border-color: transparent transparent hsl(0, 0%, 96%) hsl(0, 0%, 96%) !important;
+}
+.button.is-light.is-outlined.is-loading:hover::after, .button.is-light.is-outlined.is-loading.is-hovered::after, .button.is-light.is-outlined.is-loading:focus::after, .button.is-light.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+.button.is-light.is-outlined[disabled], fieldset[disabled] .button.is-light.is-outlined {
+  background-color: transparent;
+  border-color: hsl(0, 0%, 96%);
+  box-shadow: none;
+  color: hsl(0, 0%, 96%);
+}
+.button.is-light.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-light.is-inverted.is-outlined:hover, .button.is-light.is-inverted.is-outlined.is-hovered, .button.is-light.is-inverted.is-outlined:focus, .button.is-light.is-inverted.is-outlined.is-focused {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: hsl(0, 0%, 96%);
+}
+.button.is-light.is-inverted.is-outlined.is-loading:hover::after, .button.is-light.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-light.is-inverted.is-outlined.is-loading:focus::after, .button.is-light.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent hsl(0, 0%, 96%) hsl(0, 0%, 96%) !important;
+}
+.button.is-light.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-light.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.7);
+}
+.button.is-dark {
+  background-color: hsl(0, 0%, 21%);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-dark:hover, .button.is-dark.is-hovered {
+  background-color: #2f2f2f;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-dark:focus, .button.is-dark.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-dark:focus:not(:active), .button.is-dark.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+.button.is-dark:active, .button.is-dark.is-active, .table-of-progress .step :hover .button.is-dark.number, .table-of-progress .step :hover .button.is-dark.is-active {
+  background-color: #292929;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-dark[disabled], fieldset[disabled] .button.is-dark {
+  background-color: hsl(0, 0%, 21%);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-dark.is-inverted {
+  background-color: #fff;
+  color: hsl(0, 0%, 21%);
+}
+.button.is-dark.is-inverted:hover, .button.is-dark.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-dark.is-inverted[disabled], fieldset[disabled] .button.is-dark.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: hsl(0, 0%, 21%);
+}
+.button.is-dark.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-dark.is-outlined {
+  background-color: transparent;
+  border-color: hsl(0, 0%, 21%);
+  color: hsl(0, 0%, 21%);
+}
+.button.is-dark.is-outlined:hover, .button.is-dark.is-outlined.is-hovered, .button.is-dark.is-outlined:focus, .button.is-dark.is-outlined.is-focused {
+  background-color: hsl(0, 0%, 21%);
+  border-color: hsl(0, 0%, 21%);
+  color: #fff;
+}
+.button.is-dark.is-outlined.is-loading::after {
+  border-color: transparent transparent hsl(0, 0%, 21%) hsl(0, 0%, 21%) !important;
+}
+.button.is-dark.is-outlined.is-loading:hover::after, .button.is-dark.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-outlined.is-loading:focus::after, .button.is-dark.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-dark.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-outlined {
+  background-color: transparent;
+  border-color: hsl(0, 0%, 21%);
+  box-shadow: none;
+  color: hsl(0, 0%, 21%);
+}
+.button.is-dark.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-dark.is-inverted.is-outlined:hover, .button.is-dark.is-inverted.is-outlined.is-hovered, .button.is-dark.is-inverted.is-outlined:focus, .button.is-dark.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: hsl(0, 0%, 21%);
+}
+.button.is-dark.is-inverted.is-outlined.is-loading:hover::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-dark.is-inverted.is-outlined.is-loading:focus::after, .button.is-dark.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent hsl(0, 0%, 21%) hsl(0, 0%, 21%) !important;
+}
+.button.is-dark.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-dark.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-primary {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-primary:hover, .button.is-primary.is-hovered {
+  background-color: #d53300;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-primary:focus, .button.is-primary.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-primary:focus:not(:active), .button.is-primary.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.button.is-primary:active, .button.is-primary.is-active, .table-of-progress .step :hover .button.is-primary.number, .table-of-progress .step :hover .button.is-primary.is-active {
+  background-color: #c93000;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-primary[disabled], fieldset[disabled] .button.is-primary {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-primary.is-inverted {
+  background-color: #fff;
+  color: rgb(226, 54, 0);
+}
+.button.is-primary.is-inverted:hover, .button.is-primary.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-primary.is-inverted[disabled], fieldset[disabled] .button.is-primary.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(226, 54, 0);
+}
+.button.is-primary.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-primary.is-outlined {
+  background-color: transparent;
+  border-color: rgb(226, 54, 0);
+  color: rgb(226, 54, 0);
+}
+.button.is-primary.is-outlined:hover, .button.is-primary.is-outlined.is-hovered, .button.is-primary.is-outlined:focus, .button.is-primary.is-outlined.is-focused {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.button.is-primary.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(226, 54, 0) rgb(226, 54, 0) !important;
+}
+.button.is-primary.is-outlined.is-loading:hover::after, .button.is-primary.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-outlined.is-loading:focus::after, .button.is-primary.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-primary.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-outlined {
+  background-color: transparent;
+  border-color: rgb(226, 54, 0);
+  box-shadow: none;
+  color: rgb(226, 54, 0);
+}
+.button.is-primary.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-primary.is-inverted.is-outlined:hover, .button.is-primary.is-inverted.is-outlined.is-hovered, .button.is-primary.is-inverted.is-outlined:focus, .button.is-primary.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(226, 54, 0);
+}
+.button.is-primary.is-inverted.is-outlined.is-loading:hover::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-primary.is-inverted.is-outlined.is-loading:focus::after, .button.is-primary.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(226, 54, 0) rgb(226, 54, 0) !important;
+}
+.button.is-primary.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-primary.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-primary.is-light {
+  background-color: #ffefeb;
+  color: #eb3800;
+}
+.button.is-primary.is-light:hover, .button.is-primary.is-light.is-hovered {
+  background-color: #ffe6de;
+  border-color: transparent;
+  color: #eb3800;
+}
+.button.is-primary.is-light:active, .button.is-primary.is-light.is-active, .table-of-progress .step :hover .button.is-primary.is-light.number {
+  background-color: #ffdcd1;
+  border-color: transparent;
+  color: #eb3800;
+}
+.button.is-link {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-link:hover, .button.is-link.is-hovered {
+  background-color: #d53300;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-link:focus, .button.is-link.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-link:focus:not(:active), .button.is-link.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.button.is-link:active, .button.is-link.is-active, .table-of-progress .step :hover .button.is-link.number, .table-of-progress .step :hover .button.is-link.is-active {
+  background-color: #c93000;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-link[disabled], fieldset[disabled] .button.is-link {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-link.is-inverted {
+  background-color: #fff;
+  color: rgb(226, 54, 0);
+}
+.button.is-link.is-inverted:hover, .button.is-link.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-link.is-inverted[disabled], fieldset[disabled] .button.is-link.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(226, 54, 0);
+}
+.button.is-link.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-link.is-outlined {
+  background-color: transparent;
+  border-color: rgb(226, 54, 0);
+  color: rgb(226, 54, 0);
+}
+.button.is-link.is-outlined:hover, .button.is-link.is-outlined.is-hovered, .button.is-link.is-outlined:focus, .button.is-link.is-outlined.is-focused {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.button.is-link.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(226, 54, 0) rgb(226, 54, 0) !important;
+}
+.button.is-link.is-outlined.is-loading:hover::after, .button.is-link.is-outlined.is-loading.is-hovered::after, .button.is-link.is-outlined.is-loading:focus::after, .button.is-link.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-link.is-outlined[disabled], fieldset[disabled] .button.is-link.is-outlined {
+  background-color: transparent;
+  border-color: rgb(226, 54, 0);
+  box-shadow: none;
+  color: rgb(226, 54, 0);
+}
+.button.is-link.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-link.is-inverted.is-outlined:hover, .button.is-link.is-inverted.is-outlined.is-hovered, .button.is-link.is-inverted.is-outlined:focus, .button.is-link.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(226, 54, 0);
+}
+.button.is-link.is-inverted.is-outlined.is-loading:hover::after, .button.is-link.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-link.is-inverted.is-outlined.is-loading:focus::after, .button.is-link.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(226, 54, 0) rgb(226, 54, 0) !important;
+}
+.button.is-link.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-link.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-link.is-light {
+  background-color: #ffefeb;
+  color: #eb3800;
+}
+.button.is-link.is-light:hover, .button.is-link.is-light.is-hovered {
+  background-color: #ffe6de;
+  border-color: transparent;
+  color: #eb3800;
+}
+.button.is-link.is-light:active, .button.is-link.is-light.is-active, .table-of-progress .step :hover .button.is-link.is-light.number {
+  background-color: #ffdcd1;
+  border-color: transparent;
+  color: #eb3800;
+}
+.button.is-info {
+  background-color: rgb(25, 80, 184);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-info:hover, .button.is-info.is-hovered {
+  background-color: #174bad;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-info:focus, .button.is-info.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-info:focus:not(:active), .button.is-info.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(25, 80, 184, 0.25);
+}
+.button.is-info:active, .button.is-info.is-active, .table-of-progress .step :hover .button.is-info.number, .table-of-progress .step :hover .button.is-info.is-active {
+  background-color: #1646a2;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-info[disabled], fieldset[disabled] .button.is-info {
+  background-color: rgb(25, 80, 184);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-info.is-inverted {
+  background-color: #fff;
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-inverted:hover, .button.is-info.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-info.is-inverted[disabled], fieldset[disabled] .button.is-info.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-info.is-outlined {
+  background-color: transparent;
+  border-color: rgb(25, 80, 184);
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-outlined:hover, .button.is-info.is-outlined.is-hovered, .button.is-info.is-outlined:focus, .button.is-info.is-outlined.is-focused {
+  background-color: rgb(25, 80, 184);
+  border-color: rgb(25, 80, 184);
+  color: #fff;
+}
+.button.is-info.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(25, 80, 184) rgb(25, 80, 184) !important;
+}
+.button.is-info.is-outlined.is-loading:hover::after, .button.is-info.is-outlined.is-loading.is-hovered::after, .button.is-info.is-outlined.is-loading:focus::after, .button.is-info.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-info.is-outlined[disabled], fieldset[disabled] .button.is-info.is-outlined {
+  background-color: transparent;
+  border-color: rgb(25, 80, 184);
+  box-shadow: none;
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-info.is-inverted.is-outlined:hover, .button.is-info.is-inverted.is-outlined.is-hovered, .button.is-info.is-inverted.is-outlined:focus, .button.is-info.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-inverted.is-outlined.is-loading:hover::after, .button.is-info.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-info.is-inverted.is-outlined.is-loading:focus::after, .button.is-info.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(25, 80, 184) rgb(25, 80, 184) !important;
+}
+.button.is-info.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-info.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-info.is-light {
+  background-color: rgb(209, 220, 241);
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-light:hover, .button.is-info.is-light.is-hovered {
+  background-color: #c7d5ee;
+  border-color: transparent;
+  color: rgb(25, 80, 184);
+}
+.button.is-info.is-light:active, .button.is-info.is-light.is-active, .table-of-progress .step :hover .button.is-info.is-light.number {
+  background-color: #bdcdeb;
+  border-color: transparent;
+  color: rgb(25, 80, 184);
+}
+.button.is-success {
+  background-color: rgb(0, 131, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-success:hover, .button.is-success.is-hovered {
+  background-color: #007600;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-success:focus, .button.is-success.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-success:focus:not(:active), .button.is-success.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(0, 131, 0, 0.25);
+}
+.button.is-success:active, .button.is-success.is-active, .table-of-progress .step :hover .button.is-success.number, .table-of-progress .step :hover .button.is-success.is-active {
+  background-color: #006a00;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-success[disabled], fieldset[disabled] .button.is-success {
+  background-color: rgb(0, 131, 0);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-success.is-inverted {
+  background-color: #fff;
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-inverted:hover, .button.is-success.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-success.is-inverted[disabled], fieldset[disabled] .button.is-success.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-success.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 131, 0);
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-outlined:hover, .button.is-success.is-outlined.is-hovered, .button.is-success.is-outlined:focus, .button.is-success.is-outlined.is-focused {
+  background-color: rgb(0, 131, 0);
+  border-color: rgb(0, 131, 0);
+  color: #fff;
+}
+.button.is-success.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(0, 131, 0) rgb(0, 131, 0) !important;
+}
+.button.is-success.is-outlined.is-loading:hover::after, .button.is-success.is-outlined.is-loading.is-hovered::after, .button.is-success.is-outlined.is-loading:focus::after, .button.is-success.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-success.is-outlined[disabled], fieldset[disabled] .button.is-success.is-outlined {
+  background-color: transparent;
+  border-color: rgb(0, 131, 0);
+  box-shadow: none;
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-success.is-inverted.is-outlined:hover, .button.is-success.is-inverted.is-outlined.is-hovered, .button.is-success.is-inverted.is-outlined:focus, .button.is-success.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-inverted.is-outlined.is-loading:hover::after, .button.is-success.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-success.is-inverted.is-outlined.is-loading:focus::after, .button.is-success.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(0, 131, 0) rgb(0, 131, 0) !important;
+}
+.button.is-success.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-success.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-success.is-light {
+  background-color: rgb(224, 242, 191);
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-light:hover, .button.is-success.is-light.is-hovered {
+  background-color: #dbf0b4;
+  border-color: transparent;
+  color: rgb(0, 131, 0);
+}
+.button.is-success.is-light:active, .button.is-success.is-light.is-active, .table-of-progress .step :hover .button.is-success.is-light.number {
+  background-color: #d6eeaa;
+  border-color: transparent;
+  color: rgb(0, 131, 0);
+}
+.button.is-warning {
+  background-color: rgb(242, 171, 32);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-warning:hover, .button.is-warning.is-hovered {
+  background-color: #f1a614;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-warning:focus, .button.is-warning.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-warning:focus:not(:active), .button.is-warning.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(242, 171, 32, 0.25);
+}
+.button.is-warning:active, .button.is-warning.is-active, .table-of-progress .step :hover .button.is-warning.number, .table-of-progress .step :hover .button.is-warning.is-active {
+  background-color: #eba00e;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-warning[disabled], fieldset[disabled] .button.is-warning {
+  background-color: rgb(242, 171, 32);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-warning.is-inverted {
+  background-color: #fff;
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-inverted:hover, .button.is-warning.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-warning.is-inverted[disabled], fieldset[disabled] .button.is-warning.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-warning.is-outlined {
+  background-color: transparent;
+  border-color: rgb(242, 171, 32);
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-outlined:hover, .button.is-warning.is-outlined.is-hovered, .button.is-warning.is-outlined:focus, .button.is-warning.is-outlined.is-focused {
+  background-color: rgb(242, 171, 32);
+  border-color: rgb(242, 171, 32);
+  color: #fff;
+}
+.button.is-warning.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(242, 171, 32) rgb(242, 171, 32) !important;
+}
+.button.is-warning.is-outlined.is-loading:hover::after, .button.is-warning.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-outlined.is-loading:focus::after, .button.is-warning.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-warning.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-outlined {
+  background-color: transparent;
+  border-color: rgb(242, 171, 32);
+  box-shadow: none;
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-warning.is-inverted.is-outlined:hover, .button.is-warning.is-inverted.is-outlined.is-hovered, .button.is-warning.is-inverted.is-outlined:focus, .button.is-warning.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-inverted.is-outlined.is-loading:hover::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-warning.is-inverted.is-outlined.is-loading:focus::after, .button.is-warning.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(242, 171, 32) rgb(242, 171, 32) !important;
+}
+.button.is-warning.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-warning.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-warning.is-light {
+  background-color: rgb(250, 236, 188);
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-light:hover, .button.is-warning.is-light.is-hovered {
+  background-color: #f9e9b0;
+  border-color: transparent;
+  color: rgb(242, 171, 32);
+}
+.button.is-warning.is-light:active, .button.is-warning.is-light.is-active, .table-of-progress .step :hover .button.is-warning.is-light.number {
+  background-color: #f8e5a4;
+  border-color: transparent;
+  color: rgb(242, 171, 32);
+}
+.button.is-danger {
+  background-color: rgb(200, 59, 30);
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-danger:hover, .button.is-danger.is-hovered {
+  background-color: #bd381c;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-danger:focus, .button.is-danger.is-focused {
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(200, 59, 30, 0.25);
+}
+.button.is-danger:active, .button.is-danger.is-active, .table-of-progress .step :hover .button.is-danger.number, .table-of-progress .step :hover .button.is-danger.is-active {
+  background-color: #b2341b;
+  border-color: transparent;
+  color: #fff;
+}
+.button.is-danger[disabled], fieldset[disabled] .button.is-danger {
+  background-color: rgb(200, 59, 30);
+  border-color: transparent;
+  box-shadow: none;
+}
+.button.is-danger.is-inverted {
+  background-color: #fff;
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-inverted:hover, .button.is-danger.is-inverted.is-hovered {
+  background-color: #f2f2f2;
+}
+.button.is-danger.is-inverted[disabled], fieldset[disabled] .button.is-danger.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-danger.is-outlined {
+  background-color: transparent;
+  border-color: rgb(200, 59, 30);
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-outlined:hover, .button.is-danger.is-outlined.is-hovered, .button.is-danger.is-outlined:focus, .button.is-danger.is-outlined.is-focused {
+  background-color: rgb(200, 59, 30);
+  border-color: rgb(200, 59, 30);
+  color: #fff;
+}
+.button.is-danger.is-outlined.is-loading::after {
+  border-color: transparent transparent rgb(200, 59, 30) rgb(200, 59, 30) !important;
+}
+.button.is-danger.is-outlined.is-loading:hover::after, .button.is-danger.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-outlined.is-loading:focus::after, .button.is-danger.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+.button.is-danger.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-outlined {
+  background-color: transparent;
+  border-color: rgb(200, 59, 30);
+  box-shadow: none;
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined.is-hovered, .button.is-danger.is-inverted.is-outlined:focus, .button.is-danger.is-inverted.is-outlined.is-focused {
+  background-color: #fff;
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-inverted.is-outlined.is-loading:hover::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-inverted.is-outlined.is-loading:focus::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after {
+  border-color: transparent transparent rgb(200, 59, 30) rgb(200, 59, 30) !important;
+}
+.button.is-danger.is-inverted.is-outlined[disabled], fieldset[disabled] .button.is-danger.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+.button.is-danger.is-light {
+  background-color: rgb(255, 201, 201);
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-light:hover, .button.is-danger.is-light.is-hovered {
+  background-color: #ffbcbc;
+  border-color: transparent;
+  color: rgb(200, 59, 30);
+}
+.button.is-danger.is-light:active, .button.is-danger.is-light.is-active, .table-of-progress .step :hover .button.is-danger.is-light.number {
+  background-color: #ffb0b0;
+  border-color: transparent;
+  color: rgb(200, 59, 30);
+}
+.button.is-small {
+  border-radius: 2px;
+  font-size: 0.8rem;
+}
+.button.is-normal {
+  font-size: 1rem;
+}
+.button.is-medium {
+  font-size: 1.12rem;
+}
+.button.is-large {
+  font-size: 1.43rem;
+}
+.button[disabled], fieldset[disabled] .button {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(245, 245, 245);
+  box-shadow: none;
+  opacity: 0.5;
+}
+.button.is-fullwidth {
+  display: flex;
+  width: 100%;
+}
+.button.is-loading {
+  color: transparent !important;
+  pointer-events: none;
+}
+.button.is-loading::after {
+  position: absolute;
+  left: calc(50% - 1em / 2);
+  top: calc(50% - 1em / 2);
+  position: absolute !important;
+}
+.button.is-static {
+  background-color: hsl(0, 0%, 96%);
+  border-color: rgb(245, 245, 245);
+  color: rgb(176, 176, 176);
+  box-shadow: none;
+  pointer-events: none;
+}
+.button.is-rounded, .image .button.profile {
+  border-radius: 290486px;
+  padding-left: calc(1em + 0.25em);
+  padding-right: calc(1em + 0.25em);
+}
+
+.buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+.buttons .button {
+  margin-bottom: 0.5rem;
+}
+.buttons .button:not(:last-child):not(.is-fullwidth) {
+  margin-right: 0.5rem;
+}
+.buttons:last-child {
+  margin-bottom: -0.5rem;
+}
+.buttons:not(:last-child) {
+  margin-bottom: 1rem;
+}
+.buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large) {
+  border-radius: 2px;
+  font-size: 0.8rem;
+}
+.buttons.are-medium .button:not(.is-small):not(.is-normal):not(.is-large) {
+  font-size: 1.12rem;
+}
+.buttons.are-large .button:not(.is-small):not(.is-normal):not(.is-medium) {
+  font-size: 1.43rem;
+}
+.buttons.has-addons .button:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.buttons.has-addons .button:not(:last-child) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  margin-right: -1px;
+}
+.buttons.has-addons .button:last-child {
+  margin-right: 0;
+}
+.buttons.has-addons .button:hover, .buttons.has-addons .button.is-hovered {
+  z-index: 2;
+}
+.buttons.has-addons .button:focus, .buttons.has-addons .button.is-focused, .buttons.has-addons .button:active, .buttons.has-addons .button.is-active, .buttons.has-addons .table-of-progress .step :hover .button.number, .table-of-progress .step :hover .buttons.has-addons .button.number, .buttons.has-addons .button.is-selected {
+  z-index: 3;
+}
+.buttons.has-addons .button:focus:hover, .buttons.has-addons .button.is-focused:hover, .buttons.has-addons .button:active:hover, .buttons.has-addons .button.is-active:hover, .buttons.has-addons .table-of-progress .step :hover .button.number:hover, .table-of-progress .step :hover .buttons.has-addons .button.number:hover, .buttons.has-addons .button.is-selected:hover {
+  z-index: 4;
+}
+.buttons.has-addons .button.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.buttons.is-centered {
+  justify-content: center;
+}
+.buttons.is-centered:not(.has-addons) .button:not(.is-fullwidth) {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+.buttons.is-right {
+  justify-content: flex-end;
+}
+.buttons.is-right:not(.has-addons) .button:not(.is-fullwidth) {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.button {
+  text-transform: uppercase;
+  font-weight: 600;
+  line-height: 0;
+  border: 0.125rem solid rgb(118, 118, 118);
+  color: rgb(118, 118, 118);
+  background-color: rgb(255, 255, 255);
+  font-size: 1.43rem;
+  padding: calc(2rem - 0.187rem) 2.5rem;
+}
+.button:hover {
+  background-color: rgb(118, 118, 118);
+  border-color: rgb(118, 118, 118);
+  color: rgb(255, 255, 255);
+  text-decoration: none;
+}
+.button.big {
+  font-size: 1.75rem;
+  padding: calc(2.5rem - 0.093rem) 2.5rem;
+}
+.button.small {
+  font-size: 1rem;
+  padding: 0.5rem calc(1rem + 0.2rem);
+}
+.button.tiny {
+  font-family: "Source Sans Pro", sans-serif;
+  padding: 0 0.5rem;
+  font-size: 1rem;
+  text-transform: none;
+  height: 2rem;
+}
+.button.tag {
+  font-family: "Source Sans Pro", sans-serif;
+  padding: 0 1rem;
+  font-size: 0.81rem;
+  text-transform: none;
+  min-height: 1.81rem;
+  height: auto;
+  line-height: normal;
+  white-space: normal;
+  border-radius: 18.75rem;
+  border: 0.125rem solid rgb(216, 216, 216);
+}
+.button.tag:hover {
+  border-color: rgb(118, 118, 118);
+}
+.button.tag--removable {
+  font-family: "Source Sans Pro", sans-serif;
+  padding: 0 1rem;
+  font-size: 0.81rem;
+  text-transform: none;
+  height: 1.81rem;
+  border-radius: 18.75rem;
+  border: 0.125rem solid rgb(216, 216, 216);
+}
+.button.tag--removable:hover {
+  color: rgb(118, 118, 118);
+  background-color: rgb(255, 255, 255);
+  border: 0.125rem solid rgb(118, 118, 118);
+}
+.button.tag--removable:hover > .icon {
+  color: rgb(255, 255, 255);
+  background-color: rgb(118, 118, 118);
+}
+.button.tag--removable:hover > .icon:first-child:last-child {
+  margin-right: calc(-1rem - 1px);
+}
+.button.tag--removable .icon {
+  height: 1.56rem;
+  width: 1.9rem;
+  line-height: 1.56rem;
+  font-size: 1rem;
+  background-color: rgb(255, 255, 255);
+  color: rgb(216, 216, 216);
+  border-top-right-radius: 18.75rem;
+  border-bottom-right-radius: 18.75rem;
+}
+.button.tag--removable .icon:first-child:last-child {
+  margin-left: 0.3rem;
+  margin-right: -1rem;
+}
+.button.is-primary:hover {
+  background-color: rgb(255, 105, 51);
+}
+.button.is-success:hover {
+  background-color: rgb(0, 184, 80);
+}
+.button.is-info:hover {
+  background-color: rgb(16, 102, 231);
+}
+.button.donate {
+  background-color: rgb(239, 190, 0);
+  border-color: rgb(239, 190, 0);
+  color: rgb(0, 0, 0);
+}
+.button.donate:hover {
+  background-color: rgb(245, 212, 0);
+  border-color: rgb(245, 212, 0);
+  color: rgb(0, 0, 0);
+  text-decoration: none;
+}
+.button.is-text {
+  height: auto !important;
+  line-height: normal;
+  text-align: left;
+  text-decoration: none;
+  white-space: normal;
+}
+.button.is-text:hover, .button.is-text:active, .button.is-text:focus {
+  border-color: transparent;
+  box-shadow: none;
+  background-color: transparent;
+}
+
+/* Bulma Form */
+.select select, .textarea, .input {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(216, 216, 216);
+  border-radius: 4px;
+  color: rgb(51, 51, 51);
+}
+.select select::-moz-placeholder, .textarea::-moz-placeholder, .input::-moz-placeholder {
+  color: rgba(51, 51, 51, 0.3);
+}
+.select select::-webkit-input-placeholder, .textarea::-webkit-input-placeholder, .input::-webkit-input-placeholder {
+  color: rgba(51, 51, 51, 0.3);
+}
+.select select:-moz-placeholder, .textarea:-moz-placeholder, .input:-moz-placeholder {
+  color: rgba(51, 51, 51, 0.3);
+}
+.select select:-ms-input-placeholder, .textarea:-ms-input-placeholder, .input:-ms-input-placeholder {
+  color: rgba(51, 51, 51, 0.3);
+}
+.select select:hover, .textarea:hover, .input:hover, .select select.is-hovered, .is-hovered.textarea, .is-hovered.input {
+  border-color: rgb(176, 176, 176);
+}
+.select select:focus, .textarea:focus, .input:focus, .select select.is-focused, .is-focused.textarea, .is-focused.input, .select select:active, .textarea:active, .input:active, .select select.is-active, .select .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select select.number, .select .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select select.is-active, .is-active.textarea, .table-of-progress .step :hover .textarea.number, .table-of-progress .step :hover .textarea.is-active, .is-active.input, .table-of-progress .step :hover .input.number, .table-of-progress .step :hover .input.is-active {
+  border-color: rgb(176, 176, 176);
+  box-shadow: 0 0 0 0.125em none;
+}
+.select select[disabled], [disabled].textarea, [disabled].input, fieldset[disabled] .select select, .select fieldset[disabled] select, fieldset[disabled] .textarea, fieldset[disabled] .input {
+  background-color: hsl(0, 0%, 96%);
+  border-color: rgb(176, 176, 176);
+  box-shadow: none;
+  color: rgb(176, 176, 176);
+}
+.select select[disabled]::-moz-placeholder, [disabled].textarea::-moz-placeholder, [disabled].input::-moz-placeholder, fieldset[disabled] .select select::-moz-placeholder, .select fieldset[disabled] select::-moz-placeholder, fieldset[disabled] .textarea::-moz-placeholder, fieldset[disabled] .input::-moz-placeholder {
+  color: rgba(176, 176, 176, 0.3);
+}
+.select select[disabled]::-webkit-input-placeholder, [disabled].textarea::-webkit-input-placeholder, [disabled].input::-webkit-input-placeholder, fieldset[disabled] .select select::-webkit-input-placeholder, .select fieldset[disabled] select::-webkit-input-placeholder, fieldset[disabled] .textarea::-webkit-input-placeholder, fieldset[disabled] .input::-webkit-input-placeholder {
+  color: rgba(176, 176, 176, 0.3);
+}
+.select select[disabled]:-moz-placeholder, [disabled].textarea:-moz-placeholder, [disabled].input:-moz-placeholder, fieldset[disabled] .select select:-moz-placeholder, .select fieldset[disabled] select:-moz-placeholder, fieldset[disabled] .textarea:-moz-placeholder, fieldset[disabled] .input:-moz-placeholder {
+  color: rgba(176, 176, 176, 0.3);
+}
+.select select[disabled]:-ms-input-placeholder, [disabled].textarea:-ms-input-placeholder, [disabled].input:-ms-input-placeholder, fieldset[disabled] .select select:-ms-input-placeholder, .select fieldset[disabled] select:-ms-input-placeholder, fieldset[disabled] .textarea:-ms-input-placeholder, fieldset[disabled] .input:-ms-input-placeholder {
+  color: rgba(176, 176, 176, 0.3);
+}
+
+.textarea, .input {
+  box-shadow: none;
+  max-width: 100%;
+  width: 100%;
+}
+[readonly].textarea, [readonly].input {
+  box-shadow: none;
+}
+.is-white.textarea, .is-white.input {
+  border-color: rgb(255, 255, 255);
+}
+.is-white.textarea:focus, .is-white.input:focus, .is-white.is-focused.textarea, .is-white.is-focused.input, .is-white.textarea:active, .is-white.input:active, .is-white.is-active.textarea, .table-of-progress .step :hover .is-white.textarea.number, .table-of-progress .step :hover .is-white.textarea.is-active, .is-white.is-active.input, .table-of-progress .step :hover .is-white.input.number, .table-of-progress .step :hover .is-white.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+.is-black.textarea, .is-black.input {
+  border-color: rgb(0, 0, 0);
+}
+.is-black.textarea:focus, .is-black.input:focus, .is-black.is-focused.textarea, .is-black.is-focused.input, .is-black.textarea:active, .is-black.input:active, .is-black.is-active.textarea, .table-of-progress .step :hover .is-black.textarea.number, .table-of-progress .step :hover .is-black.textarea.is-active, .is-black.is-active.input, .table-of-progress .step :hover .is-black.input.number, .table-of-progress .step :hover .is-black.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(0, 0, 0, 0.25);
+}
+.is-light.textarea, .is-light.input {
+  border-color: hsl(0, 0%, 96%);
+}
+.is-light.textarea:focus, .is-light.input:focus, .is-light.is-focused.textarea, .is-light.is-focused.input, .is-light.textarea:active, .is-light.input:active, .is-light.is-active.textarea, .table-of-progress .step :hover .is-light.textarea.number, .table-of-progress .step :hover .is-light.textarea.is-active, .is-light.is-active.input, .table-of-progress .step :hover .is-light.input.number, .table-of-progress .step :hover .is-light.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+.is-dark.textarea, .is-dark.input {
+  border-color: hsl(0, 0%, 21%);
+}
+.is-dark.textarea:focus, .is-dark.input:focus, .is-dark.is-focused.textarea, .is-dark.is-focused.input, .is-dark.textarea:active, .is-dark.input:active, .is-dark.is-active.textarea, .table-of-progress .step :hover .is-dark.textarea.number, .table-of-progress .step :hover .is-dark.textarea.is-active, .is-dark.is-active.input, .table-of-progress .step :hover .is-dark.input.number, .table-of-progress .step :hover .is-dark.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+.is-primary.textarea, .is-primary.input {
+  border-color: rgb(226, 54, 0);
+}
+.is-primary.textarea:focus, .is-primary.input:focus, .is-primary.is-focused.textarea, .is-primary.is-focused.input, .is-primary.textarea:active, .is-primary.input:active, .is-primary.is-active.textarea, .table-of-progress .step :hover .is-primary.textarea.number, .table-of-progress .step :hover .is-primary.textarea.is-active, .is-primary.is-active.input, .table-of-progress .step :hover .is-primary.input.number, .table-of-progress .step :hover .is-primary.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.is-link.textarea, .is-link.input {
+  border-color: rgb(226, 54, 0);
+}
+.is-link.textarea:focus, .is-link.input:focus, .is-link.is-focused.textarea, .is-link.is-focused.input, .is-link.textarea:active, .is-link.input:active, .is-link.is-active.textarea, .table-of-progress .step :hover .is-link.textarea.number, .table-of-progress .step :hover .is-link.textarea.is-active, .is-link.is-active.input, .table-of-progress .step :hover .is-link.input.number, .table-of-progress .step :hover .is-link.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.is-info.textarea, .is-info.input {
+  border-color: rgb(25, 80, 184);
+}
+.is-info.textarea:focus, .is-info.input:focus, .is-info.is-focused.textarea, .is-info.is-focused.input, .is-info.textarea:active, .is-info.input:active, .is-info.is-active.textarea, .table-of-progress .step :hover .is-info.textarea.number, .table-of-progress .step :hover .is-info.textarea.is-active, .is-info.is-active.input, .table-of-progress .step :hover .is-info.input.number, .table-of-progress .step :hover .is-info.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(25, 80, 184, 0.25);
+}
+.is-success.textarea, .is-success.input {
+  border-color: rgb(0, 131, 0);
+}
+.is-success.textarea:focus, .is-success.input:focus, .is-success.is-focused.textarea, .is-success.is-focused.input, .is-success.textarea:active, .is-success.input:active, .is-success.is-active.textarea, .table-of-progress .step :hover .is-success.textarea.number, .table-of-progress .step :hover .is-success.textarea.is-active, .is-success.is-active.input, .table-of-progress .step :hover .is-success.input.number, .table-of-progress .step :hover .is-success.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(0, 131, 0, 0.25);
+}
+.is-warning.textarea, .is-warning.input {
+  border-color: rgb(242, 171, 32);
+}
+.is-warning.textarea:focus, .is-warning.input:focus, .is-warning.is-focused.textarea, .is-warning.is-focused.input, .is-warning.textarea:active, .is-warning.input:active, .is-warning.is-active.textarea, .table-of-progress .step :hover .is-warning.textarea.number, .table-of-progress .step :hover .is-warning.textarea.is-active, .is-warning.is-active.input, .table-of-progress .step :hover .is-warning.input.number, .table-of-progress .step :hover .is-warning.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(242, 171, 32, 0.25);
+}
+.is-danger.textarea, .is-danger.input {
+  border-color: rgb(200, 59, 30);
+}
+.is-danger.textarea:focus, .is-danger.input:focus, .is-danger.is-focused.textarea, .is-danger.is-focused.input, .is-danger.textarea:active, .is-danger.input:active, .is-danger.is-active.textarea, .table-of-progress .step :hover .is-danger.textarea.number, .table-of-progress .step :hover .is-danger.textarea.is-active, .is-danger.is-active.input, .table-of-progress .step :hover .is-danger.input.number, .table-of-progress .step :hover .is-danger.input.is-active {
+  box-shadow: 0 0 0 0.125em rgba(200, 59, 30, 0.25);
+}
+.is-small.textarea, .is-small.input {
+  border-radius: 2px;
+  font-size: 0.8rem;
+}
+.is-medium.textarea, .is-medium.input {
+  font-size: 1.12rem;
+}
+.is-large.textarea, .is-large.input {
+  font-size: 1.43rem;
+}
+.is-fullwidth.textarea, .is-fullwidth.input {
+  display: block;
+  width: 100%;
+}
+.is-inline.textarea, .is-inline.input {
+  display: inline;
+  width: auto;
+}
+
+.input.is-rounded, .image .input.profile {
+  border-radius: 290486px;
+  padding-left: calc(calc(0.75em - 1px) + 0.375em);
+  padding-right: calc(calc(0.75em - 1px) + 0.375em);
+}
+.input.is-static {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.textarea {
+  display: block;
+  max-width: 100%;
+  min-width: 100%;
+  padding: calc(0.75em - 1px);
+  resize: vertical;
+}
+.textarea:not([rows]) {
+  max-height: 40em;
+  min-height: 8em;
+}
+.textarea[rows] {
+  height: initial;
+}
+.textarea.has-fixed-size {
+  resize: none;
+}
+
+.radio, .checkbox {
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1.25;
+  position: relative;
+}
+.radio input, .checkbox input {
+  cursor: pointer;
+}
+.radio:hover, .checkbox:hover {
+  color: hsl(0, 0%, 21%);
+}
+[disabled].radio, [disabled].checkbox, fieldset[disabled] .radio, fieldset[disabled] .checkbox,
+.radio input[disabled],
+.checkbox input[disabled] {
+  color: rgb(176, 176, 176);
+  cursor: not-allowed;
+}
+
+.radio + .radio {
+  margin-left: 0.5em;
+}
+
+.select {
+  display: inline-block;
+  max-width: 100%;
+  position: relative;
+  vertical-align: top;
+}
+.select:not(.is-multiple) {
+  height: 2.5em;
+}
+.select:not(.is-multiple):not(.is-loading)::after {
+  border-color: rgb(226, 54, 0);
+  right: 1.125em;
+  z-index: 4;
+}
+.select.is-rounded select, .image .select.profile select {
+  border-radius: 290486px;
+  padding-left: 1em;
+}
+.select select {
+  cursor: pointer;
+  display: block;
+  font-size: 1em;
+  max-width: 100%;
+  outline: none;
+}
+.select select::-ms-expand {
+  display: none;
+}
+.select select[disabled]:hover, fieldset[disabled] .select select:hover {
+  border-color: rgb(176, 176, 176);
+}
+.select select:not([multiple]) {
+  padding-right: 2.5em;
+}
+.select select[multiple] {
+  height: auto;
+  padding: 0;
+}
+.select select[multiple] option {
+  padding: 0.5em 1em;
+}
+.select:not(.is-multiple):not(.is-loading):hover::after {
+  border-color: hsl(0, 0%, 21%);
+}
+.select.is-white:not(:hover)::after {
+  border-color: rgb(255, 255, 255);
+}
+.select.is-white select {
+  border-color: rgb(255, 255, 255);
+}
+.select.is-white select:hover, .select.is-white select.is-hovered {
+  border-color: #f2f2f2;
+}
+.select.is-white select:focus, .select.is-white select.is-focused, .select.is-white select:active, .select.is-white select.is-active, .select.is-white .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-white select.number, .select.is-white .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-white select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+.select.is-black:not(:hover)::after {
+  border-color: rgb(0, 0, 0);
+}
+.select.is-black select {
+  border-color: rgb(0, 0, 0);
+}
+.select.is-black select:hover, .select.is-black select.is-hovered {
+  border-color: black;
+}
+.select.is-black select:focus, .select.is-black select.is-focused, .select.is-black select:active, .select.is-black select.is-active, .select.is-black .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-black select.number, .select.is-black .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-black select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(0, 0, 0, 0.25);
+}
+.select.is-light:not(:hover)::after {
+  border-color: hsl(0, 0%, 96%);
+}
+.select.is-light select {
+  border-color: hsl(0, 0%, 96%);
+}
+.select.is-light select:hover, .select.is-light select.is-hovered {
+  border-color: #e8e8e8;
+}
+.select.is-light select:focus, .select.is-light select.is-focused, .select.is-light select:active, .select.is-light select.is-active, .select.is-light .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-light select.number, .select.is-light .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-light select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+.select.is-dark:not(:hover)::after {
+  border-color: hsl(0, 0%, 21%);
+}
+.select.is-dark select {
+  border-color: hsl(0, 0%, 21%);
+}
+.select.is-dark select:hover, .select.is-dark select.is-hovered {
+  border-color: #292929;
+}
+.select.is-dark select:focus, .select.is-dark select.is-focused, .select.is-dark select:active, .select.is-dark select.is-active, .select.is-dark .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-dark select.number, .select.is-dark .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-dark select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+.select.is-primary:not(:hover)::after {
+  border-color: rgb(226, 54, 0);
+}
+.select.is-primary select {
+  border-color: rgb(226, 54, 0);
+}
+.select.is-primary select:hover, .select.is-primary select.is-hovered {
+  border-color: #c93000;
+}
+.select.is-primary select:focus, .select.is-primary select.is-focused, .select.is-primary select:active, .select.is-primary select.is-active, .select.is-primary .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-primary select.number, .select.is-primary .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-primary select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.select.is-link:not(:hover)::after {
+  border-color: rgb(226, 54, 0);
+}
+.select.is-link select {
+  border-color: rgb(226, 54, 0);
+}
+.select.is-link select:hover, .select.is-link select.is-hovered {
+  border-color: #c93000;
+}
+.select.is-link select:focus, .select.is-link select.is-focused, .select.is-link select:active, .select.is-link select.is-active, .select.is-link .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-link select.number, .select.is-link .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-link select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(226, 54, 0, 0.25);
+}
+.select.is-info:not(:hover)::after {
+  border-color: rgb(25, 80, 184);
+}
+.select.is-info select {
+  border-color: rgb(25, 80, 184);
+}
+.select.is-info select:hover, .select.is-info select.is-hovered {
+  border-color: #1646a2;
+}
+.select.is-info select:focus, .select.is-info select.is-focused, .select.is-info select:active, .select.is-info select.is-active, .select.is-info .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-info select.number, .select.is-info .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-info select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(25, 80, 184, 0.25);
+}
+.select.is-success:not(:hover)::after {
+  border-color: rgb(0, 131, 0);
+}
+.select.is-success select {
+  border-color: rgb(0, 131, 0);
+}
+.select.is-success select:hover, .select.is-success select.is-hovered {
+  border-color: #006a00;
+}
+.select.is-success select:focus, .select.is-success select.is-focused, .select.is-success select:active, .select.is-success select.is-active, .select.is-success .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-success select.number, .select.is-success .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-success select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(0, 131, 0, 0.25);
+}
+.select.is-warning:not(:hover)::after {
+  border-color: rgb(242, 171, 32);
+}
+.select.is-warning select {
+  border-color: rgb(242, 171, 32);
+}
+.select.is-warning select:hover, .select.is-warning select.is-hovered {
+  border-color: #eba00e;
+}
+.select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active, .select.is-warning .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-warning select.number, .select.is-warning .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-warning select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(242, 171, 32, 0.25);
+}
+.select.is-danger:not(:hover)::after {
+  border-color: rgb(200, 59, 30);
+}
+.select.is-danger select {
+  border-color: rgb(200, 59, 30);
+}
+.select.is-danger select:hover, .select.is-danger select.is-hovered {
+  border-color: #b2341b;
+}
+.select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active, .select.is-danger .table-of-progress .step :hover select.number, .table-of-progress .step :hover .select.is-danger select.number, .select.is-danger .table-of-progress .step :hover select.is-active, .table-of-progress .step :hover .select.is-danger select.is-active {
+  box-shadow: 0 0 0 0.125em rgba(200, 59, 30, 0.25);
+}
+.select.is-small {
+  border-radius: 2px;
+  font-size: 0.8rem;
+}
+.select.is-medium {
+  font-size: 1.12rem;
+}
+.select.is-large {
+  font-size: 1.43rem;
+}
+.select.is-disabled::after {
+  border-color: rgb(176, 176, 176);
+}
+.select.is-fullwidth {
+  width: 100%;
+}
+.select.is-fullwidth select {
+  width: 100%;
+}
+.select.is-loading::after {
+  margin-top: 0;
+  position: absolute;
+  right: 0.625em;
+  top: 0.625em;
+  transform: none;
+}
+.select.is-loading.is-small:after {
+  font-size: 0.8rem;
+}
+.select.is-loading.is-medium:after {
+  font-size: 1.12rem;
+}
+.select.is-loading.is-large:after {
+  font-size: 1.43rem;
+}
+
+.file {
+  align-items: stretch;
+  display: flex;
+  justify-content: flex-start;
+  position: relative;
+}
+.file.is-white .file-cta {
+  background-color: rgb(255, 255, 255);
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.file.is-white:hover .file-cta, .file.is-white.is-hovered .file-cta {
+  background-color: #f9f9f9;
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.file.is-white:focus .file-cta, .file.is-white.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(255, 255, 255, 0.25);
+  color: rgb(0, 0, 0);
+}
+.file.is-white:active .file-cta, .file.is-white.is-active .file-cta, .table-of-progress .step :hover .file.is-white.number .file-cta {
+  background-color: #f2f2f2;
+  border-color: transparent;
+  color: rgb(0, 0, 0);
+}
+.file.is-black .file-cta {
+  background-color: rgb(0, 0, 0);
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.file.is-black:hover .file-cta, .file.is-black.is-hovered .file-cta {
+  background-color: black;
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.file.is-black:focus .file-cta, .file.is-black.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.25);
+  color: rgb(255, 255, 255);
+}
+.file.is-black:active .file-cta, .file.is-black.is-active .file-cta, .table-of-progress .step :hover .file.is-black.number .file-cta {
+  background-color: black;
+  border-color: transparent;
+  color: rgb(255, 255, 255);
+}
+.file.is-light .file-cta {
+  background-color: hsl(0, 0%, 96%);
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.file.is-light:hover .file-cta, .file.is-light.is-hovered .file-cta {
+  background-color: #eeeeee;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.file.is-light:focus .file-cta, .file.is-light.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
+  color: rgba(0, 0, 0, 0.7);
+}
+.file.is-light:active .file-cta, .file.is-light.is-active .file-cta, .table-of-progress .step :hover .file.is-light.number .file-cta {
+  background-color: #e8e8e8;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+.file.is-dark .file-cta {
+  background-color: hsl(0, 0%, 21%);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-dark:hover .file-cta, .file.is-dark.is-hovered .file-cta {
+  background-color: #2f2f2f;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-dark:focus .file-cta, .file.is-dark.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(54, 54, 54, 0.25);
+  color: #fff;
+}
+.file.is-dark:active .file-cta, .file.is-dark.is-active .file-cta, .table-of-progress .step :hover .file.is-dark.number .file-cta {
+  background-color: #292929;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-primary .file-cta {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-primary:hover .file-cta, .file.is-primary.is-hovered .file-cta {
+  background-color: #d53300;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-primary:focus .file-cta, .file.is-primary.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(226, 54, 0, 0.25);
+  color: #fff;
+}
+.file.is-primary:active .file-cta, .file.is-primary.is-active .file-cta, .table-of-progress .step :hover .file.is-primary.number .file-cta {
+  background-color: #c93000;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-link .file-cta {
+  background-color: rgb(226, 54, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-link:hover .file-cta, .file.is-link.is-hovered .file-cta {
+  background-color: #d53300;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-link:focus .file-cta, .file.is-link.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(226, 54, 0, 0.25);
+  color: #fff;
+}
+.file.is-link:active .file-cta, .file.is-link.is-active .file-cta, .table-of-progress .step :hover .file.is-link.number .file-cta {
+  background-color: #c93000;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-info .file-cta {
+  background-color: rgb(25, 80, 184);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-info:hover .file-cta, .file.is-info.is-hovered .file-cta {
+  background-color: #174bad;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-info:focus .file-cta, .file.is-info.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(25, 80, 184, 0.25);
+  color: #fff;
+}
+.file.is-info:active .file-cta, .file.is-info.is-active .file-cta, .table-of-progress .step :hover .file.is-info.number .file-cta {
+  background-color: #1646a2;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-success .file-cta {
+  background-color: rgb(0, 131, 0);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-success:hover .file-cta, .file.is-success.is-hovered .file-cta {
+  background-color: #007600;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-success:focus .file-cta, .file.is-success.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(0, 131, 0, 0.25);
+  color: #fff;
+}
+.file.is-success:active .file-cta, .file.is-success.is-active .file-cta, .table-of-progress .step :hover .file.is-success.number .file-cta {
+  background-color: #006a00;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-warning .file-cta {
+  background-color: rgb(242, 171, 32);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-warning:hover .file-cta, .file.is-warning.is-hovered .file-cta {
+  background-color: #f1a614;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-warning:focus .file-cta, .file.is-warning.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(242, 171, 32, 0.25);
+  color: #fff;
+}
+.file.is-warning:active .file-cta, .file.is-warning.is-active .file-cta, .table-of-progress .step :hover .file.is-warning.number .file-cta {
+  background-color: #eba00e;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-danger .file-cta {
+  background-color: rgb(200, 59, 30);
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
+  background-color: #bd381c;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(200, 59, 30, 0.25);
+  color: #fff;
+}
+.file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta, .table-of-progress .step :hover .file.is-danger.number .file-cta {
+  background-color: #b2341b;
+  border-color: transparent;
+  color: #fff;
+}
+.file.is-small {
+  font-size: 0.8rem;
+}
+.file.is-medium {
+  font-size: 1.12rem;
+}
+.file.is-medium .file-icon .fa {
+  font-size: 21px;
+}
+.file.is-large {
+  font-size: 1.43rem;
+}
+.file.is-large .file-icon .fa {
+  font-size: 28px;
+}
+.file.has-name .file-cta {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.file.has-name .file-name {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.file.has-name.is-empty .file-cta {
+  border-radius: 4px;
+}
+.file.has-name.is-empty .file-name {
+  display: none;
+}
+.file.is-boxed .file-label {
+  flex-direction: column;
+}
+.file.is-boxed .file-cta {
+  flex-direction: column;
+  height: auto;
+  padding: 1em 3em;
+}
+.file.is-boxed .file-name {
+  border-width: 0 1px 1px;
+}
+.file.is-boxed .file-icon {
+  height: 1.5em;
+  width: 1.5em;
+}
+.file.is-boxed .file-icon .fa {
+  font-size: 21px;
+}
+.file.is-boxed.is-small .file-icon .fa {
+  font-size: 14px;
+}
+.file.is-boxed.is-medium .file-icon .fa {
+  font-size: 28px;
+}
+.file.is-boxed.is-large .file-icon .fa {
+  font-size: 35px;
+}
+.file.is-boxed.has-name .file-cta {
+  border-radius: 4px 4px 0 0;
+}
+.file.is-boxed.has-name .file-name {
+  border-radius: 0 0 4px 4px;
+  border-width: 0 1px 1px;
+}
+.file.is-centered {
+  justify-content: center;
+}
+.file.is-fullwidth .file-label {
+  width: 100%;
+}
+.file.is-fullwidth .file-name {
+  flex-grow: 1;
+  max-width: none;
+}
+.file.is-right {
+  justify-content: flex-end;
+}
+.file.is-right .file-cta {
+  border-radius: 0 4px 4px 0;
+}
+.file.is-right .file-name {
+  border-radius: 4px 0 0 4px;
+  border-width: 1px 0 1px 1px;
+  order: -1;
+}
+
+.file-label {
+  align-items: stretch;
+  display: flex;
+  cursor: pointer;
+  justify-content: flex-start;
+  overflow: hidden;
+  position: relative;
+}
+.file-label:hover .file-cta {
+  background-color: #eeeeee;
+  color: hsl(0, 0%, 21%);
+}
+.file-label:hover .file-name {
+  border-color: #efefef;
+}
+.file-label:active .file-cta {
+  background-color: #e8e8e8;
+  color: hsl(0, 0%, 21%);
+}
+.file-label:active .file-name {
+  border-color: #e8e8e8;
+}
+
+.file-input {
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  outline: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.file-cta,
+.file-name {
+  border-color: rgb(245, 245, 245);
+  border-radius: 4px;
+  font-size: 1em;
+  padding-left: 1em;
+  padding-right: 1em;
+  white-space: nowrap;
+}
+
+.file-cta {
+  background-color: hsl(0, 0%, 96%);
+  color: rgb(118, 118, 118);
+}
+
+.file-name {
+  border-color: rgb(245, 245, 245);
+  border-style: solid;
+  border-width: 1px 1px 1px 0;
+  display: block;
+  max-width: 16em;
+  overflow: hidden;
+  text-align: inherit;
+  text-overflow: ellipsis;
+}
+
+.file-icon {
+  align-items: center;
+  display: flex;
+  height: 1em;
+  justify-content: center;
+  margin-right: 0.5em;
+  width: 1em;
+}
+.file-icon .fa {
+  font-size: 14px;
+}
+
+.label {
+  color: hsl(0, 0%, 21%);
+  display: block;
+  font-size: 1rem;
+  font-weight: 700;
+}
+.label:not(:last-child) {
+  margin-bottom: 0.5em;
+}
+.label.is-small {
+  font-size: 0.8rem;
+}
+.label.is-medium {
+  font-size: 1.12rem;
+}
+.label.is-large {
+  font-size: 1.43rem;
+}
+
+.help {
+  display: block;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+.help.is-white {
+  color: rgb(255, 255, 255);
+}
+.help.is-black {
+  color: rgb(0, 0, 0);
+}
+.help.is-light {
+  color: hsl(0, 0%, 96%);
+}
+.help.is-dark {
+  color: hsl(0, 0%, 21%);
+}
+.help.is-primary {
+  color: rgb(226, 54, 0);
+}
+.help.is-link {
+  color: rgb(226, 54, 0);
+}
+.help.is-info {
+  color: rgb(25, 80, 184);
+}
+.help.is-success {
+  color: rgb(0, 131, 0);
+}
+.help.is-warning {
+  color: rgb(242, 171, 32);
+}
+.help.is-danger {
+  color: rgb(200, 59, 30);
+}
+
+.field:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+.field.has-addons {
+  display: flex;
+  justify-content: flex-start;
+}
+.field.has-addons .control:not(:last-child) {
+  margin-right: -1px;
+}
+.field.has-addons .control:not(:first-child):not(:last-child) .button,
+.field.has-addons .control:not(:first-child):not(:last-child) .input,
+.field.has-addons .control:not(:first-child):not(:last-child) .select select {
+  border-radius: 0;
+}
+.field.has-addons .control:first-child:not(:only-child) .button,
+.field.has-addons .control:first-child:not(:only-child) .input,
+.field.has-addons .control:first-child:not(:only-child) .select select {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.field.has-addons .control:last-child:not(:only-child) .button,
+.field.has-addons .control:last-child:not(:only-child) .input,
+.field.has-addons .control:last-child:not(:only-child) .select select {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
+.field.has-addons .control .input:not([disabled]):hover,
+.field.has-addons .control .input:not([disabled]).is-hovered,
+.field.has-addons .control .select select:not([disabled]):hover,
+.field.has-addons .control .select select:not([disabled]).is-hovered {
+  z-index: 2;
+}
+.field.has-addons .control .button:not([disabled]):focus, .field.has-addons .control .button:not([disabled]).is-focused, .field.has-addons .control .button:not([disabled]):active, .field.has-addons .control .button:not([disabled]).is-active, .field.has-addons .control .table-of-progress .step :hover .button.number:not([disabled]), .table-of-progress .step :hover .field.has-addons .control .button.number:not([disabled]),
+.field.has-addons .control .input:not([disabled]):focus,
+.field.has-addons .control .input:not([disabled]).is-focused,
+.field.has-addons .control .input:not([disabled]):active,
+.field.has-addons .control .input:not([disabled]).is-active,
+.field.has-addons .control .table-of-progress .step :hover .input.number:not([disabled]),
+.table-of-progress .step :hover .field.has-addons .control .input.number:not([disabled]),
+.field.has-addons .control .select select:not([disabled]):focus,
+.field.has-addons .control .select select:not([disabled]).is-focused,
+.field.has-addons .control .select select:not([disabled]):active,
+.field.has-addons .control .select select:not([disabled]).is-active,
+.field.has-addons .control .select .table-of-progress .step :hover select.number:not([disabled]),
+.table-of-progress .step :hover .field.has-addons .control .select select.number:not([disabled]) {
+  z-index: 3;
+}
+.field.has-addons .control .button:not([disabled]):focus:hover, .field.has-addons .control .button:not([disabled]).is-focused:hover, .field.has-addons .control .button:not([disabled]):active:hover, .field.has-addons .control .button:not([disabled]).is-active:hover, .field.has-addons .control .table-of-progress .step :hover .button.number:not([disabled]):hover, .table-of-progress .step :hover .field.has-addons .control .button.number:not([disabled]):hover,
+.field.has-addons .control .input:not([disabled]):focus:hover,
+.field.has-addons .control .input:not([disabled]).is-focused:hover,
+.field.has-addons .control .input:not([disabled]):active:hover,
+.field.has-addons .control .input:not([disabled]).is-active:hover,
+.field.has-addons .control .table-of-progress .step :hover .input.number:not([disabled]):hover,
+.table-of-progress .step :hover .field.has-addons .control .input.number:not([disabled]):hover,
+.field.has-addons .control .select select:not([disabled]):focus:hover,
+.field.has-addons .control .select select:not([disabled]).is-focused:hover,
+.field.has-addons .control .select select:not([disabled]):active:hover,
+.field.has-addons .control .select select:not([disabled]).is-active:hover,
+.field.has-addons .control .select .table-of-progress .step :hover select.number:not([disabled]):hover,
+.table-of-progress .step :hover .field.has-addons .control .select select.number:not([disabled]):hover {
+  z-index: 4;
+}
+.field.has-addons .control.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.field.has-addons.has-addons-centered {
+  justify-content: center;
+}
+.field.has-addons.has-addons-right {
+  justify-content: flex-end;
+}
+.field.has-addons.has-addons-fullwidth .control {
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+.field.is-grouped {
+  display: flex;
+  justify-content: flex-start;
+}
+.field.is-grouped > .control {
+  flex-shrink: 0;
+}
+.field.is-grouped > .control:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 0.75rem;
+}
+.field.is-grouped > .control.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.field.is-grouped.is-grouped-centered {
+  justify-content: center;
+}
+.field.is-grouped.is-grouped-right {
+  justify-content: flex-end;
+}
+.field.is-grouped.is-grouped-multiline {
+  flex-wrap: wrap;
+}
+.field.is-grouped.is-grouped-multiline > .control:last-child, .field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+.field.is-grouped.is-grouped-multiline:last-child {
+  margin-bottom: -0.75rem;
+}
+.field.is-grouped.is-grouped-multiline:not(:last-child) {
+  margin-bottom: 0;
+}
+@media screen and (min-width: 769px), print {
+  .field.is-horizontal {
+    display: flex;
+  }
+}
+
+.field-label .label {
+  font-size: inherit;
+}
+@media screen and (max-width: 768px) {
+  .field-label {
+    margin-bottom: 0.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .field-label {
+    flex-basis: 0;
+    flex-grow: 1;
+    flex-shrink: 0;
+    margin-right: 1.5rem;
+    text-align: right;
+  }
+  .field-label.is-small {
+    font-size: 0.8rem;
+    padding-top: 0.375em;
+  }
+  .field-label.is-normal {
+    padding-top: 0.375em;
+  }
+  .field-label.is-medium {
+    font-size: 1.12rem;
+    padding-top: 0.375em;
+  }
+  .field-label.is-large {
+    font-size: 1.43rem;
+    padding-top: 0.375em;
+  }
+}
+
+.field-body .field .field {
+  margin-bottom: 0;
+}
+@media screen and (min-width: 769px), print {
+  .field-body {
+    display: flex;
+    flex-basis: 0;
+    flex-grow: 5;
+    flex-shrink: 1;
+  }
+  .field-body .field {
+    margin-bottom: 0;
+  }
+  .field-body > .field {
+    flex-shrink: 1;
+  }
+  .field-body > .field:not(.is-narrow) {
+    flex-grow: 1;
+  }
+  .field-body > .field:not(:last-child) {
+    margin-right: 0.75rem;
+  }
+}
+
+.control {
+  box-sizing: border-box;
+  clear: both;
+  font-size: 1rem;
+  position: relative;
+  text-align: inherit;
+}
+.control.has-icons-left .input:focus ~ .icon,
+.control.has-icons-left .select:focus ~ .icon, .control.has-icons-right .input:focus ~ .icon,
+.control.has-icons-right .select:focus ~ .icon {
+  color: rgb(176, 176, 176);
+}
+.control.has-icons-left .input.is-small ~ .icon,
+.control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
+.control.has-icons-right .select.is-small ~ .icon {
+  font-size: 0.8rem;
+}
+.control.has-icons-left .input.is-medium ~ .icon,
+.control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
+.control.has-icons-right .select.is-medium ~ .icon {
+  font-size: 1.12rem;
+}
+.control.has-icons-left .input.is-large ~ .icon,
+.control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
+.control.has-icons-right .select.is-large ~ .icon {
+  font-size: 1.43rem;
+}
+.control.has-icons-left .icon, .control.has-icons-right .icon {
+  color: rgb(216, 216, 216);
+  height: 2.5em;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 2.5em;
+  z-index: 4;
+}
+.control.has-icons-left .input,
+.control.has-icons-left .select select {
+  padding-left: 2.5em;
+}
+.control.has-icons-left .icon.is-left {
+  left: 0;
+}
+.control.has-icons-right .input,
+.control.has-icons-right .select select {
+  padding-right: 2.5em;
+}
+.control.has-icons-right .icon.is-right {
+  right: 0;
+}
+.control.is-loading::after {
+  position: absolute !important;
+  right: 0.625em;
+  top: 0.625em;
+  z-index: 4;
+}
+.control.is-loading.is-small:after {
+  font-size: 0.8rem;
+}
+.control.is-loading.is-medium:after {
+  font-size: 1.12rem;
+}
+.control.is-loading.is-large:after {
+  font-size: 1.43rem;
+}
+
+.input {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  line-height: 1.3;
+  border-width: 0.125rem;
+  box-sizing: border-box;
+  height: 2.5em;
+  padding-left: 0.5rem;
+}
+.input.is-medium {
+  font-size: 1.43rem;
+  height: 3.875rem;
+  padding-left: 1rem;
+}
+.input.is-large {
+  font-size: 1.75rem;
+  height: 5.063rem;
+  padding-left: 1.5rem;
+}
+
+.textarea {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  line-height: 1.3;
+  border-width: 0.125rem;
+  box-sizing: border-box;
+  min-height: 6.875em;
+  resize: both;
+}
+
+.select select {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  line-height: 1.3;
+  border-width: 0.125rem;
+}
+.select select option {
+  font-weight: 400;
+}
+.select:not(.is-multiple):not(.is-loading)::after {
+  background: linear-gradient(45deg, rgb(0, 0, 0) 50%, transparent 50%);
+  border: none;
+  border-radius: 0;
+}
+
+.control {
+  box-sizing: border-box;
+  clear: both;
+  font-size: 1rem;
+  position: relative;
+  text-align: left;
+}
+.control.has-icons-left .icon, .control.has-icons-right .icon {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+}
+.control.has-icons-left .icon .icon, .control.has-icons-right .icon .icon {
+  color: inherit;
+  position: unset;
+}
+.control.has-icons-left .input:focus ~ .icon, .control.has-icons-left .input:hover ~ .icon,
+.control.has-icons-left .select:focus ~ .icon,
+.control.has-icons-left .select:hover ~ .icon, .control.has-icons-right .input:focus ~ .icon, .control.has-icons-right .input:hover ~ .icon,
+.control.has-icons-right .select:focus ~ .icon,
+.control.has-icons-right .select:hover ~ .icon {
+  color: rgb(176, 176, 176);
+}
+.control.has-icons-left .input:disabled ~ .icon,
+.control.has-icons-left .select:disabled ~ .icon, .control.has-icons-right .input:disabled ~ .icon,
+.control.has-icons-right .select:disabled ~ .icon {
+  color: rgba(176, 176, 176, 0.3);
+}
+.control.has-icons-left .input.is-small ~ .icon,
+.control.has-icons-left .select.is-small ~ .icon, .control.has-icons-right .input.is-small ~ .icon,
+.control.has-icons-right .select.is-small ~ .icon {
+  font-size: 0.8rem;
+  height: 2.5em;
+}
+.control.has-icons-left .input.is-medium ~ .icon,
+.control.has-icons-left .select.is-medium ~ .icon, .control.has-icons-right .input.is-medium ~ .icon,
+.control.has-icons-right .select.is-medium ~ .icon {
+  font-size: 1.43rem;
+  height: 3.875rem;
+}
+.control.has-icons-left .input.is-large ~ .icon,
+.control.has-icons-left .select.is-large ~ .icon, .control.has-icons-right .input.is-large ~ .icon,
+.control.has-icons-right .select.is-large ~ .icon {
+  font-size: 1.75rem;
+  height: 5.063rem;
+}
+.control.has-icons-left .icon, .control.has-icons-right .icon {
+  color: rgb(216, 216, 216);
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  z-index: 4;
+}
+.control.has-icons-left .icon.is-left {
+  left: 0;
+}
+.control.has-icons-right .icon.is-right {
+  right: 0;
+}
+
+.container {
+  flex-grow: 1;
+  margin: 0 auto;
+  position: relative;
+  width: auto;
+}
+.container.is-fluid {
+  max-width: none !important;
+  padding-left: 32px;
+  padding-right: 32px;
+  width: 100%;
+}
+@media screen and (min-width: 1024px) {
+  .container {
+    max-width: 960px;
+  }
+}
+@media screen and (max-width: 1215px) {
+  .container.is-widescreen:not(.is-max-desktop) {
+    max-width: 1152px;
+  }
+}
+@media screen and (max-width: 1311px) {
+  .container.is-fullhd:not(.is-max-desktop):not(.is-max-widescreen) {
+    max-width: 1248px;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .container:not(.is-max-desktop) {
+    max-width: 1152px;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .container:not(.is-max-desktop):not(.is-max-widescreen) {
+    max-width: 1248px;
+  }
+}
+
+/* Bulma Grid */
+.column {
+  display: block;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  padding: 0.75rem;
+}
+.columns.is-mobile > .column.is-narrow {
+  flex: none;
+}
+.columns.is-mobile > .column.is-full {
+  flex: none;
+  width: 100%;
+}
+.columns.is-mobile > .column.is-three-quarters {
+  flex: none;
+  width: 75%;
+}
+.columns.is-mobile > .column.is-two-thirds {
+  flex: none;
+  width: 66.6666%;
+}
+.columns.is-mobile > .column.is-half {
+  flex: none;
+  width: 50%;
+}
+.columns.is-mobile > .column.is-one-third {
+  flex: none;
+  width: 33.3333%;
+}
+.columns.is-mobile > .column.is-one-quarter {
+  flex: none;
+  width: 25%;
+}
+.columns.is-mobile > .column.is-one-fifth {
+  flex: none;
+  width: 20%;
+}
+.columns.is-mobile > .column.is-two-fifths {
+  flex: none;
+  width: 40%;
+}
+.columns.is-mobile > .column.is-three-fifths {
+  flex: none;
+  width: 60%;
+}
+.columns.is-mobile > .column.is-four-fifths {
+  flex: none;
+  width: 80%;
+}
+.columns.is-mobile > .column.is-offset-three-quarters {
+  margin-left: 75%;
+}
+.columns.is-mobile > .column.is-offset-two-thirds {
+  margin-left: 66.6666%;
+}
+.columns.is-mobile > .column.is-offset-half {
+  margin-left: 50%;
+}
+.columns.is-mobile > .column.is-offset-one-third {
+  margin-left: 33.3333%;
+}
+.columns.is-mobile > .column.is-offset-one-quarter {
+  margin-left: 25%;
+}
+.columns.is-mobile > .column.is-offset-one-fifth {
+  margin-left: 20%;
+}
+.columns.is-mobile > .column.is-offset-two-fifths {
+  margin-left: 40%;
+}
+.columns.is-mobile > .column.is-offset-three-fifths {
+  margin-left: 60%;
+}
+.columns.is-mobile > .column.is-offset-four-fifths {
+  margin-left: 80%;
+}
+.columns.is-mobile > .column.is-0 {
+  flex: none;
+  width: 0%;
+}
+.columns.is-mobile > .column.is-offset-0 {
+  margin-left: 0%;
+}
+.columns.is-mobile > .column.is-1 {
+  flex: none;
+  width: 8.3333333333%;
+}
+.columns.is-mobile > .column.is-offset-1 {
+  margin-left: 8.3333333333%;
+}
+.columns.is-mobile > .column.is-2 {
+  flex: none;
+  width: 16.6666666667%;
+}
+.columns.is-mobile > .column.is-offset-2 {
+  margin-left: 16.6666666667%;
+}
+.columns.is-mobile > .column.is-3 {
+  flex: none;
+  width: 25%;
+}
+.columns.is-mobile > .column.is-offset-3 {
+  margin-left: 25%;
+}
+.columns.is-mobile > .column.is-4 {
+  flex: none;
+  width: 33.3333333333%;
+}
+.columns.is-mobile > .column.is-offset-4 {
+  margin-left: 33.3333333333%;
+}
+.columns.is-mobile > .column.is-5 {
+  flex: none;
+  width: 41.6666666667%;
+}
+.columns.is-mobile > .column.is-offset-5 {
+  margin-left: 41.6666666667%;
+}
+.columns.is-mobile > .column.is-6 {
+  flex: none;
+  width: 50%;
+}
+.columns.is-mobile > .column.is-offset-6 {
+  margin-left: 50%;
+}
+.columns.is-mobile > .column.is-7 {
+  flex: none;
+  width: 58.3333333333%;
+}
+.columns.is-mobile > .column.is-offset-7 {
+  margin-left: 58.3333333333%;
+}
+.columns.is-mobile > .column.is-8 {
+  flex: none;
+  width: 66.6666666667%;
+}
+.columns.is-mobile > .column.is-offset-8 {
+  margin-left: 66.6666666667%;
+}
+.columns.is-mobile > .column.is-9 {
+  flex: none;
+  width: 75%;
+}
+.columns.is-mobile > .column.is-offset-9 {
+  margin-left: 75%;
+}
+.columns.is-mobile > .column.is-10 {
+  flex: none;
+  width: 83.3333333333%;
+}
+.columns.is-mobile > .column.is-offset-10 {
+  margin-left: 83.3333333333%;
+}
+.columns.is-mobile > .column.is-11 {
+  flex: none;
+  width: 91.6666666667%;
+}
+.columns.is-mobile > .column.is-offset-11 {
+  margin-left: 91.6666666667%;
+}
+.columns.is-mobile > .column.is-12 {
+  flex: none;
+  width: 100%;
+}
+.columns.is-mobile > .column.is-offset-12 {
+  margin-left: 100%;
+}
+@media screen and (max-width: 768px) {
+  .column.is-narrow-mobile {
+    flex: none;
+  }
+  .column.is-full-mobile {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-mobile {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-mobile {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-mobile {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-mobile {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-mobile {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth-mobile {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths-mobile {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths-mobile {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths-mobile {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters-mobile {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-mobile {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-mobile {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-mobile {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-mobile {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth-mobile {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths-mobile {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths-mobile {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths-mobile {
+    margin-left: 80%;
+  }
+  .column.is-0-mobile {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0-mobile {
+    margin-left: 0%;
+  }
+  .column.is-1-mobile {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1-mobile {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2-mobile {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2-mobile {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3-mobile {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-mobile {
+    margin-left: 25%;
+  }
+  .column.is-4-mobile {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4-mobile {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5-mobile {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5-mobile {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6-mobile {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-mobile {
+    margin-left: 50%;
+  }
+  .column.is-7-mobile {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7-mobile {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8-mobile {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8-mobile {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9-mobile {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-mobile {
+    margin-left: 75%;
+  }
+  .column.is-10-mobile {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10-mobile {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11-mobile {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11-mobile {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12-mobile {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-mobile {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .column.is-narrow, .column.is-narrow-tablet {
+    flex: none;
+  }
+  .column.is-full, .column.is-full-tablet {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters, .column.is-three-quarters-tablet {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds, .column.is-two-thirds-tablet {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half, .column.is-half-tablet {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third, .column.is-one-third-tablet {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter, .column.is-one-quarter-tablet {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth, .column.is-one-fifth-tablet {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths, .column.is-two-fifths-tablet {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths, .column.is-three-fifths-tablet {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths, .column.is-four-fifths-tablet {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half, .column.is-offset-half-tablet {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third, .column.is-offset-one-third-tablet {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
+    margin-left: 80%;
+  }
+  .column.is-0, .column.is-0-tablet {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0, .column.is-offset-0-tablet {
+    margin-left: 0%;
+  }
+  .column.is-1, .column.is-1-tablet {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1, .column.is-offset-1-tablet {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2, .column.is-2-tablet {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2, .column.is-offset-2-tablet {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3, .column.is-3-tablet {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3, .column.is-offset-3-tablet {
+    margin-left: 25%;
+  }
+  .column.is-4, .column.is-4-tablet {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4, .column.is-offset-4-tablet {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5, .column.is-5-tablet {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5, .column.is-offset-5-tablet {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6, .column.is-6-tablet {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6, .column.is-offset-6-tablet {
+    margin-left: 50%;
+  }
+  .column.is-7, .column.is-7-tablet {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7, .column.is-offset-7-tablet {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8, .column.is-8-tablet {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8, .column.is-offset-8-tablet {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9, .column.is-9-tablet {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9, .column.is-offset-9-tablet {
+    margin-left: 75%;
+  }
+  .column.is-10, .column.is-10-tablet {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10, .column.is-offset-10-tablet {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11, .column.is-11-tablet {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11, .column.is-offset-11-tablet {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12, .column.is-12-tablet {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12, .column.is-offset-12-tablet {
+    margin-left: 100%;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .column.is-narrow-touch {
+    flex: none;
+  }
+  .column.is-full-touch {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-touch {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-touch {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-touch {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-touch {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-touch {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth-touch {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths-touch {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths-touch {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths-touch {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters-touch {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-touch {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-touch {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-touch {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-touch {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth-touch {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths-touch {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths-touch {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths-touch {
+    margin-left: 80%;
+  }
+  .column.is-0-touch {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0-touch {
+    margin-left: 0%;
+  }
+  .column.is-1-touch {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1-touch {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2-touch {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2-touch {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3-touch {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-touch {
+    margin-left: 25%;
+  }
+  .column.is-4-touch {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4-touch {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5-touch {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5-touch {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6-touch {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-touch {
+    margin-left: 50%;
+  }
+  .column.is-7-touch {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7-touch {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8-touch {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8-touch {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9-touch {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-touch {
+    margin-left: 75%;
+  }
+  .column.is-10-touch {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10-touch {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11-touch {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11-touch {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12-touch {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-touch {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .column.is-narrow-desktop {
+    flex: none;
+  }
+  .column.is-full-desktop {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-desktop {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-desktop {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-desktop {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-desktop {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-desktop {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth-desktop {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths-desktop {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths-desktop {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths-desktop {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters-desktop {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-desktop {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-desktop {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-desktop {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-desktop {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth-desktop {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths-desktop {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths-desktop {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths-desktop {
+    margin-left: 80%;
+  }
+  .column.is-0-desktop {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0-desktop {
+    margin-left: 0%;
+  }
+  .column.is-1-desktop {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1-desktop {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2-desktop {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2-desktop {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3-desktop {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-desktop {
+    margin-left: 25%;
+  }
+  .column.is-4-desktop {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4-desktop {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5-desktop {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5-desktop {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6-desktop {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-desktop {
+    margin-left: 50%;
+  }
+  .column.is-7-desktop {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7-desktop {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8-desktop {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8-desktop {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9-desktop {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-desktop {
+    margin-left: 75%;
+  }
+  .column.is-10-desktop {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10-desktop {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11-desktop {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11-desktop {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12-desktop {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-desktop {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .column.is-narrow-widescreen {
+    flex: none;
+  }
+  .column.is-full-widescreen {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-widescreen {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-widescreen {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-widescreen {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-widescreen {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-widescreen {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth-widescreen {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths-widescreen {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths-widescreen {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths-widescreen {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters-widescreen {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-widescreen {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-widescreen {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-widescreen {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-widescreen {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth-widescreen {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths-widescreen {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths-widescreen {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths-widescreen {
+    margin-left: 80%;
+  }
+  .column.is-0-widescreen {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0-widescreen {
+    margin-left: 0%;
+  }
+  .column.is-1-widescreen {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1-widescreen {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2-widescreen {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2-widescreen {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3-widescreen {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-widescreen {
+    margin-left: 25%;
+  }
+  .column.is-4-widescreen {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4-widescreen {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5-widescreen {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5-widescreen {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6-widescreen {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-widescreen {
+    margin-left: 50%;
+  }
+  .column.is-7-widescreen {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7-widescreen {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8-widescreen {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8-widescreen {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9-widescreen {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-widescreen {
+    margin-left: 75%;
+  }
+  .column.is-10-widescreen {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10-widescreen {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11-widescreen {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11-widescreen {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12-widescreen {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-widescreen {
+    margin-left: 100%;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .column.is-narrow-fullhd {
+    flex: none;
+  }
+  .column.is-full-fullhd {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-three-quarters-fullhd {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-two-thirds-fullhd {
+    flex: none;
+    width: 66.6666%;
+  }
+  .column.is-half-fullhd {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-one-third-fullhd {
+    flex: none;
+    width: 33.3333%;
+  }
+  .column.is-one-quarter-fullhd {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-one-fifth-fullhd {
+    flex: none;
+    width: 20%;
+  }
+  .column.is-two-fifths-fullhd {
+    flex: none;
+    width: 40%;
+  }
+  .column.is-three-fifths-fullhd {
+    flex: none;
+    width: 60%;
+  }
+  .column.is-four-fifths-fullhd {
+    flex: none;
+    width: 80%;
+  }
+  .column.is-offset-three-quarters-fullhd {
+    margin-left: 75%;
+  }
+  .column.is-offset-two-thirds-fullhd {
+    margin-left: 66.6666%;
+  }
+  .column.is-offset-half-fullhd {
+    margin-left: 50%;
+  }
+  .column.is-offset-one-third-fullhd {
+    margin-left: 33.3333%;
+  }
+  .column.is-offset-one-quarter-fullhd {
+    margin-left: 25%;
+  }
+  .column.is-offset-one-fifth-fullhd {
+    margin-left: 20%;
+  }
+  .column.is-offset-two-fifths-fullhd {
+    margin-left: 40%;
+  }
+  .column.is-offset-three-fifths-fullhd {
+    margin-left: 60%;
+  }
+  .column.is-offset-four-fifths-fullhd {
+    margin-left: 80%;
+  }
+  .column.is-0-fullhd {
+    flex: none;
+    width: 0%;
+  }
+  .column.is-offset-0-fullhd {
+    margin-left: 0%;
+  }
+  .column.is-1-fullhd {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .column.is-offset-1-fullhd {
+    margin-left: 8.3333333333%;
+  }
+  .column.is-2-fullhd {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .column.is-offset-2-fullhd {
+    margin-left: 16.6666666667%;
+  }
+  .column.is-3-fullhd {
+    flex: none;
+    width: 25%;
+  }
+  .column.is-offset-3-fullhd {
+    margin-left: 25%;
+  }
+  .column.is-4-fullhd {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .column.is-offset-4-fullhd {
+    margin-left: 33.3333333333%;
+  }
+  .column.is-5-fullhd {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .column.is-offset-5-fullhd {
+    margin-left: 41.6666666667%;
+  }
+  .column.is-6-fullhd {
+    flex: none;
+    width: 50%;
+  }
+  .column.is-offset-6-fullhd {
+    margin-left: 50%;
+  }
+  .column.is-7-fullhd {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .column.is-offset-7-fullhd {
+    margin-left: 58.3333333333%;
+  }
+  .column.is-8-fullhd {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .column.is-offset-8-fullhd {
+    margin-left: 66.6666666667%;
+  }
+  .column.is-9-fullhd {
+    flex: none;
+    width: 75%;
+  }
+  .column.is-offset-9-fullhd {
+    margin-left: 75%;
+  }
+  .column.is-10-fullhd {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .column.is-offset-10-fullhd {
+    margin-left: 83.3333333333%;
+  }
+  .column.is-11-fullhd {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .column.is-offset-11-fullhd {
+    margin-left: 91.6666666667%;
+  }
+  .column.is-12-fullhd {
+    flex: none;
+    width: 100%;
+  }
+  .column.is-offset-12-fullhd {
+    margin-left: 100%;
+  }
+}
+
+.columns {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem;
+}
+.columns:last-child {
+  margin-bottom: -0.75rem;
+}
+.columns:not(:last-child) {
+  margin-bottom: calc(1.5rem - 0.75rem);
+}
+.columns.is-centered {
+  justify-content: center;
+}
+.columns.is-gapless {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+.columns.is-gapless > .column {
+  margin: 0;
+  padding: 0 !important;
+}
+.columns.is-gapless:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+.columns.is-gapless:last-child {
+  margin-bottom: 0;
+}
+.columns.is-mobile {
+  display: flex;
+}
+.columns.is-multiline {
+  flex-wrap: wrap;
+}
+.columns.is-vcentered {
+  align-items: center;
+}
+@media screen and (min-width: 769px), print {
+  .columns:not(.is-desktop) {
+    display: flex;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-desktop {
+    display: flex;
+  }
+}
+
+.columns.is-variable {
+  --columnGap: 0.75rem;
+  margin-left: calc(-1 * var(--columnGap));
+  margin-right: calc(-1 * var(--columnGap));
+}
+.columns.is-variable .column {
+  padding-left: var(--columnGap);
+  padding-right: var(--columnGap);
+}
+.columns.is-variable.is-0 {
+  --columnGap: 0rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-0-mobile {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-0-tablet {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-0-tablet-only {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-0-touch {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-0-desktop {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-0-desktop-only {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-0-widescreen {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-0-widescreen-only {
+    --columnGap: 0rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-0-fullhd {
+    --columnGap: 0rem;
+  }
+}
+.columns.is-variable.is-1 {
+  --columnGap: 0.25rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-1-mobile {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-1-tablet {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-1-tablet-only {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-1-touch {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-1-desktop {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-1-desktop-only {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-1-widescreen {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-1-widescreen-only {
+    --columnGap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-1-fullhd {
+    --columnGap: 0.25rem;
+  }
+}
+.columns.is-variable.is-2 {
+  --columnGap: 0.5rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-2-mobile {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-2-tablet {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-2-tablet-only {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-2-touch {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-2-desktop {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-2-desktop-only {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-2-widescreen {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-2-widescreen-only {
+    --columnGap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-2-fullhd {
+    --columnGap: 0.5rem;
+  }
+}
+.columns.is-variable.is-3 {
+  --columnGap: 0.75rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-3-mobile {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-3-tablet {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-3-tablet-only {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-3-touch {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-3-desktop {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-3-desktop-only {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-3-widescreen {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-3-widescreen-only {
+    --columnGap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-3-fullhd {
+    --columnGap: 0.75rem;
+  }
+}
+.columns.is-variable.is-4 {
+  --columnGap: 1rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-4-mobile {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-4-tablet {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-4-tablet-only {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-4-touch {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-4-desktop {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-4-desktop-only {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-4-widescreen {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-4-widescreen-only {
+    --columnGap: 1rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-4-fullhd {
+    --columnGap: 1rem;
+  }
+}
+.columns.is-variable.is-5 {
+  --columnGap: 1.25rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-5-mobile {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-5-tablet {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-5-tablet-only {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-5-touch {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-5-desktop {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-5-desktop-only {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-5-widescreen {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-5-widescreen-only {
+    --columnGap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-5-fullhd {
+    --columnGap: 1.25rem;
+  }
+}
+.columns.is-variable.is-6 {
+  --columnGap: 1.5rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-6-mobile {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-6-tablet {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-6-tablet-only {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-6-touch {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-6-desktop {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-6-desktop-only {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-6-widescreen {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-6-widescreen-only {
+    --columnGap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-6-fullhd {
+    --columnGap: 1.5rem;
+  }
+}
+.columns.is-variable.is-7 {
+  --columnGap: 1.75rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-7-mobile {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-7-tablet {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-7-tablet-only {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-7-touch {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-7-desktop {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-7-desktop-only {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-7-widescreen {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-7-widescreen-only {
+    --columnGap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-7-fullhd {
+    --columnGap: 1.75rem;
+  }
+}
+.columns.is-variable.is-8 {
+  --columnGap: 2rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-8-mobile {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-8-tablet {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-8-tablet-only {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-8-touch {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-8-desktop {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-8-desktop-only {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-8-widescreen {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1311px) {
+  .columns.is-variable.is-8-widescreen-only {
+    --columnGap: 2rem;
+  }
+}
+@media screen and (min-width: 1312px) {
+  .columns.is-variable.is-8-fullhd {
+    --columnGap: 2rem;
+  }
+}
+
+.tile {
+  align-items: stretch;
+  display: block;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  min-height: min-content;
+}
+.tile.is-ancestor {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem;
+}
+.tile.is-ancestor:last-child {
+  margin-bottom: -0.75rem;
+}
+.tile.is-ancestor:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+.tile.is-child {
+  margin: 0 !important;
+}
+.tile.is-parent {
+  padding: 0.75rem;
+}
+.tile.is-vertical {
+  flex-direction: column;
+}
+.tile.is-vertical > .tile.is-child:not(:last-child) {
+  margin-bottom: 1.5rem !important;
+}
+@media screen and (min-width: 769px), print {
+  .tile:not(.is-child) {
+    display: flex;
+  }
+  .tile.is-1 {
+    flex: none;
+    width: 8.3333333333%;
+  }
+  .tile.is-2 {
+    flex: none;
+    width: 16.6666666667%;
+  }
+  .tile.is-3 {
+    flex: none;
+    width: 25%;
+  }
+  .tile.is-4 {
+    flex: none;
+    width: 33.3333333333%;
+  }
+  .tile.is-5 {
+    flex: none;
+    width: 41.6666666667%;
+  }
+  .tile.is-6 {
+    flex: none;
+    width: 50%;
+  }
+  .tile.is-7 {
+    flex: none;
+    width: 58.3333333333%;
+  }
+  .tile.is-8 {
+    flex: none;
+    width: 66.6666666667%;
+  }
+  .tile.is-9 {
+    flex: none;
+    width: 75%;
+  }
+  .tile.is-10 {
+    flex: none;
+    width: 83.3333333333%;
+  }
+  .tile.is-11 {
+    flex: none;
+    width: 91.6666666667%;
+  }
+  .tile.is-12 {
+    flex: none;
+    width: 100%;
+  }
+}
+
+.card {
+  background-color: rgb(255, 255, 255);
+  border-radius: 0.25rem;
+  box-shadow: none;
+  color: rgb(118, 118, 118);
+  max-width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.card-header {
+  background-color: transparent;
+  align-items: stretch;
+  box-shadow: none;
+  display: flex;
+}
+
+.card-header-title {
+  align-items: center;
+  color: hsl(0, 0%, 21%);
+  display: flex;
+  flex-grow: 1;
+  font-weight: 700;
+  padding: 0.75rem 1rem;
+}
+.card-header-title.is-centered {
+  justify-content: center;
+}
+
+.card-header-icon {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+}
+
+.card-image {
+  display: block;
+  position: relative;
+}
+
+.card-content {
+  background-color: transparent;
+  padding: 1.5rem;
+}
+
+.card-footer {
+  background-color: transparent;
+  border-top: 1px solid hsl(0, 0%, 93%);
+  align-items: stretch;
+  display: flex;
+}
+
+.card-footer-item {
+  align-items: center;
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 0;
+  justify-content: center;
+  padding: 0.75rem;
+}
+.card-footer-item:not(:last-child) {
+  border-right: 1px solid hsl(0, 0%, 93%);
+}
+
+.card .media:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.card.entry-post {
+  border: 3px solid rgb(216, 216, 216);
+}
+.card.entry-post.no-border {
+  border: none;
+}
+.card.entry-post .card-content {
+  padding: 1.5rem 2rem;
+}
+.card.entry-post .card-content .card-title {
+  text-transform: none;
+  line-height: 1.6rem;
+}
+.card.entry-post .card-content .card-title a {
+  color: rgb(0, 0, 0);
+}
+.card.entry-post .card-content .subtitle {
+  display: block;
+  margin-top: 1rem;
+  color: rgb(176, 176, 176);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+}
+.card.entry-post .card-content .content {
+  padding-top: 1.5rem;
+}
+.card.entry-post .card-content.with-button .content {
+  padding: 1.5rem 0;
+}
+.card.entry-post .card-content .read-more {
+  position: relative;
+  margin-top: 1.5rem;
+  text-transform: uppercase;
+  color: rgb(176, 176, 176);
+  letter-spacing: 2%;
+}
+.card.entry-post .card-content .read-more .icon {
+  padding-left: 1rem;
+}
+.card.entry-post .card-content .read-more:hover {
+  text-decoration: none;
+  color: rgb(118, 118, 118);
+}
+.card.entry-post.horizontal {
+  display: flex;
+}
+.card.entry-post.horizontal .card-content {
+  padding: 2rem;
+}
+.card.entry-post.horizontal .card-image .image {
+  height: 100%;
+}
+.card.entry-post.horizontal .card-image .image img {
+  object-fit: cover;
+  height: 100%;
+}
+.card.entry-post.entry-video .card-image a .image:before {
+  content: "\e908";
+  position: absolute;
+  padding: 1.5rem;
+  top: 0;
+  left: 0;
+  width: 5rem;
+  height: 5rem;
+  background-color: rgb(239, 190, 0);
+  color: rgb(255, 255, 255);
+  font-family: "Vocabulary Icons", monospace !important;
+  font-size: 3rem;
+  line-height: 0.7;
+  text-align: center;
+  z-index: 10;
+}
+.card.entry-post.entry-video.large > * {
+  flex: 0 0 auto;
+}
+.card.entry-post.entry-video.large .card-image {
+  width: 70%;
+}
+.card.entry-post.entry-video.large .card-image a .image:before {
+  bottom: 0;
+  right: 0;
+  margin: auto;
+}
+.card.entry-post.entry-video.large .card-image a .image img {
+  width: 100%;
+}
+.card.entry-post.entry-video.large .card-content {
+  width: 30%;
+}
+.card.entry-post.entry-video.large .card-content .card-title {
+  text-transform: uppercase;
+  line-height: 3.7rem;
+}
+.card.entry-post.entry-event .card-header {
+  width: 30%;
+  justify-content: center;
+  align-items: center;
+}
+.card.entry-post.entry-event .card-header .card-date {
+  padding: 1.5rem;
+  text-align: center;
+}
+.card.entry-post.entry-event .card-header .card-date > * {
+  display: block;
+}
+.card.entry-post.entry-event .card-header .card-date .month {
+  text-transform: uppercase;
+  color: rgb(118, 118, 118);
+}
+.card.entry-post.entry-event .card-header .card-date .day {
+  font-size: 4.4rem;
+  font-weight: 600;
+  line-height: 4rem;
+}
+.card.entry-post.entry-event .card-header .card-date .year {
+  color: rgb(118, 118, 118);
+}
+.card.entry-post.entry-event .card-content .content {
+  padding-bottom: 1.5rem;
+}
+.card.entry-post.entry-statistic .card-header {
+  width: 65%;
+  padding: 1.5rem;
+  align-items: center;
+}
+.card.entry-post.entry-statistic .card-header .card-statistic > * {
+  display: block;
+}
+.card.entry-post.entry-statistic .card-header .card-statistic .number, .card.entry-post.entry-statistic .card-header .card-statistic .table-of-progress .step .is-active, .table-of-progress .step .card.entry-post.entry-statistic .card-header .card-statistic .is-active {
+  font-size: 4.4rem;
+  font-weight: 600;
+  line-height: 4rem;
+}
+.card.entry-post.entry-statistic .card-header .card-statistic .caption, .card.entry-post.entry-statistic .card-header .card-statistic .image .image-title, .image .card.entry-post.entry-statistic .card-header .card-statistic .image-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.card.entry-post.entry-statistic .card-content .content {
+  padding-bottom: 1rem;
+  padding-top: 0;
+}
+.card.entry-post.entry-quote {
+  padding: 1.5rem;
+}
+.card.entry-post.entry-quote .card-image {
+  width: 80%;
+}
+.card.entry-post.entry-quote .card-image .image img {
+  object-fit: none;
+  height: auto;
+  border: 3px solid rgb(216, 216, 216);
+}
+.card.entry-post.entry-quote .card-content {
+  padding-top: 0;
+}
+.card.entry-post.entry-quote .card-content .quote {
+  display: block;
+  width: 46px;
+  height: 32px;
+  background-repeat: no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg width='46' height='32' viewBox='0 0 46 32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M27.3836 26.8797C25.8676 24.1902 25 21.0676 25 17.737C25 11.3769 29.1325 2.81312 39.3401 0L41.196 5.31367C36.3588 7.02275 33.1774 10.4191 32.8559 12.5458C33.8727 12.1893 34.9648 11.9956 36.1017 11.9956C41.5684 11.9956 46 16.4737 46 21.9978C46 27.5219 41.5684 32 36.1017 32C32.3717 32 29.1235 29.9151 27.4362 26.8357L27.3836 26.8797Z' fill='%23D8D8D8'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M2.38359 26.8797C0.867634 24.1902 -1.90735e-06 21.0676 -1.90735e-06 17.737C-1.90735e-06 11.3769 4.13252 2.81312 14.3401 0L16.196 5.31367C11.3588 7.02275 8.17739 10.4191 7.85587 12.5458C8.87269 12.1893 9.96483 11.9956 11.1017 11.9956C16.5684 11.9956 21 16.4737 21 21.9978C21 27.5219 16.5684 32 11.1017 32C7.37168 32 4.12352 29.9151 2.43624 26.8357L2.38359 26.8797Z' fill='%23D8D8D8'/%3E%3C/svg%3E%0A");
+}
+.card.entry-post.entry-quote .card-content .content {
+  font-size: 1.4rem;
+}
+.card.entry-post.entry-quote .card-content .content .quote-author {
+  font-size: 1rem;
+  margin-top: 1.5rem;
+}
+.card.entry-post.entry-image .card-content .card-title {
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+.card.entry-post.entry-image .card-content .card-title a {
+  color: rgb(0, 0, 0);
+}
+.card.entry-post.entry-image .card-content .card-title a:hover {
+  color: rgb(118, 118, 118);
+}
+.card.entry-post.entry-image .card-content .subtitle {
+  color: rgb(176, 176, 176);
+  font-weight: 600;
+  letter-spacing: 0.1rem;
+}
+.card.entry-post.link a {
+  display: block;
+  padding: 2rem;
+  color: rgb(0, 0, 0);
+}
+.card.entry-post.link a.has-background-tomato {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-tomato .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-gold {
+  color: rgb(0, 0, 0);
+}
+.card.entry-post.link a.has-background-forest-green {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-forest-green .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-turquoise {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-turquoise .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-slate-blue {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-slate-blue .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-brighter-dark-slate-blue {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-brighter-dark-slate-blue .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-slate-gray {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a.has-background-dark-slate-gray .card-content .card-title {
+  color: rgb(255, 255, 255);
+}
+.card.entry-post.link a .card-content {
+  display: block;
+  position: relative;
+}
+.card.entry-post.link a .card-content.has-bottom-link {
+  padding: 0 0 6rem 0;
+}
+.card.entry-post.link a .card-content .card-title {
+  text-transform: uppercase;
+  line-height: 2.5rem;
+}
+.card.entry-post.link a .card-content .content {
+  display: block;
+  font-weight: 600;
+}
+.card.entry-post.link a .card-content .link-arrow {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  text-transform: uppercase;
+}
+.card.entry-post.link a .card-content .link-arrow .icon {
+  padding-left: 1rem;
+}
+.card.entry-post.link a:hover {
+  text-decoration: none;
+}
+.card.entry-post.link a:hover.has-background-tomato {
+  background-color: #ff4e16 !important;
+}
+.card.entry-post.link a:hover.has-background-gold {
+  background-color: #ffd223 !important;
+}
+.card.entry-post.link a:hover.has-background-forest-green {
+  background-color: #00b600 !important;
+}
+.card.entry-post.link a:hover.has-background-dark-turquoise {
+  background-color: #18d3fa !important;
+}
+.card.entry-post.link a:hover.has-background-dark-slate-blue {
+  background-color: #4e73ba !important;
+}
+.card.entry-post.link a:hover.has-background-brighter-dark-slate-blue {
+  background-color: #3983f1 !important;
+}
+.card.entry-post.link a:hover.has-background-dark-slate-gray {
+  background-color: #4d4d4d !important;
+}
+.card.blog-entry {
+  background-color: transparent;
+}
+.card.blog-entry .blog-image {
+  width: 5rem;
+  height: 5rem;
+}
+.table {
+  background-color: rgb(255, 255, 255);
+  color: rgb(51, 51, 51);
+}
+.table td,
+.table th {
+  border: 1px solid rgb(216, 216, 216);
+  border-width: 0 0 1px;
+  padding: 1rem;
+  vertical-align: top;
+}
+.table td.is-white,
+.table th.is-white {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}
+.table td.is-black,
+.table th.is-black {
+  background-color: rgb(0, 0, 0);
+  border-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+}
+.table td.is-light,
+.table th.is-light {
+  background-color: hsl(0, 0%, 96%);
+  border-color: hsl(0, 0%, 96%);
+  color: rgba(0, 0, 0, 0.7);
+}
+.table td.is-dark,
+.table th.is-dark {
+  background-color: hsl(0, 0%, 21%);
+  border-color: hsl(0, 0%, 21%);
+  color: #fff;
+}
+.table td.is-primary,
+.table th.is-primary {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.table td.is-link,
+.table th.is-link {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.table td.is-info,
+.table th.is-info {
+  background-color: rgb(25, 80, 184);
+  border-color: rgb(25, 80, 184);
+  color: #fff;
+}
+.table td.is-success,
+.table th.is-success {
+  background-color: rgb(0, 131, 0);
+  border-color: rgb(0, 131, 0);
+  color: #fff;
+}
+.table td.is-warning,
+.table th.is-warning {
+  background-color: rgb(242, 171, 32);
+  border-color: rgb(242, 171, 32);
+  color: #fff;
+}
+.table td.is-danger,
+.table th.is-danger {
+  background-color: rgb(200, 59, 30);
+  border-color: rgb(200, 59, 30);
+  color: #fff;
+}
+.table td.is-narrow,
+.table th.is-narrow {
+  white-space: nowrap;
+  width: 1%;
+}
+.table td.is-selected,
+.table th.is-selected {
+  background-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.table td.is-selected a,
+.table td.is-selected strong,
+.table th.is-selected a,
+.table th.is-selected strong {
+  color: currentColor;
+}
+.table td.is-vcentered,
+.table th.is-vcentered {
+  vertical-align: middle;
+}
+.table th {
+  color: hsl(0, 0%, 21%);
+}
+.table th:not([align]) {
+  text-align: inherit;
+}
+.table tr.is-selected {
+  background-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.table tr.is-selected a,
+.table tr.is-selected strong {
+  color: currentColor;
+}
+.table tr.is-selected td,
+.table tr.is-selected th {
+  border-color: #fff;
+  color: currentColor;
+}
+.table thead {
+  background-color: rgb(216, 216, 216);
+}
+.table thead td,
+.table thead th {
+  border-width: 0 0 2px;
+  color: hsl(0, 0%, 21%);
+}
+.table tfoot {
+  background-color: transparent;
+}
+.table tfoot td,
+.table tfoot th {
+  border-width: 2px 0 0;
+  color: hsl(0, 0%, 21%);
+}
+.table tbody {
+  background-color: transparent;
+}
+.table tbody tr:last-child td,
+.table tbody tr:last-child th {
+  border-bottom-width: 0;
+}
+.table.is-bordered td,
+.table.is-bordered th {
+  border-width: 1px;
+}
+.table.is-bordered tr:last-child td,
+.table.is-bordered tr:last-child th {
+  border-bottom-width: 1px;
+}
+.table.is-fullwidth {
+  width: 100%;
+}
+.table.is-hoverable tbody tr:not(.is-selected):hover {
+  background-color: hsl(0, 0%, 98%);
+}
+.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
+  background-color: hsl(0, 0%, 98%);
+}
+.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(even) {
+  background-color: hsl(0, 0%, 96%);
+}
+.table.is-narrow td,
+.table.is-narrow th {
+  padding: 0.25em 0.5em;
+}
+.table.is-striped tbody tr:not(.is-selected):nth-child(even) {
+  background-color: rgb(245, 245, 245);
+}
+
+.table-container {
+  -webkit-overflow-scrolling: touch;
+  overflow: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+}
+
+.number-cell {
+  text-align: right !important;
+}
+
+.table {
+  line-height: 1.5;
+}
+
+@media only screen and (max-width: 760px), (min-device-width: 769px) and (max-device-width: 1024px) {
+  .is-responsive table, .is-responsive thead, .is-responsive tbody, .is-responsive th, .is-responsive td, .is-responsive tr {
+    display: block;
+  }
+  .is-responsive thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+  .is-responsive tr {
+    margin-top: 1rem;
+  }
+  .is-responsive td {
+    position: relative;
+    text-align: left !important;
+    padding-left: calc(45% + 1rem);
+    background-color: rgb(255, 255, 255);
+  }
+  .is-responsive td:nth-child(2n) {
+    background-color: rgb(245, 245, 245);
+  }
+  .is-responsive td:first-child {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
+  .is-responsive td:last-child {
+    border-bottom-left-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  .is-responsive td:before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-size: 1rem;
+    font-weight: bold;
+    line-height: 1.5;
+    height: 100%;
+    width: 45%;
+    padding: 1rem;
+    background-color: rgb(216, 216, 216);
+    border-right: 0.0625rem solid rgb(216, 216, 216);
+  }
+  .is-responsive td:nth-of-type(n):before {
+    content: attr(data-label);
+  }
+}
+
+.tabs {
+  -webkit-overflow-scrolling: touch;
+  align-items: stretch;
+  display: flex;
+  font-size: 1rem;
+  justify-content: space-between;
+  overflow: hidden;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.tabs a {
+  align-items: center;
+  border-bottom-color: rgb(216, 216, 216);
+  border-bottom-style: solid;
+  border-bottom-width: 2px;
+  color: rgb(51, 51, 51);
+  display: flex;
+  justify-content: center;
+  margin-bottom: -2px;
+  padding: 0 0 1rem 0;
+  vertical-align: top;
+}
+.tabs a:hover {
+  border-bottom-color: hsl(0, 0%, 21%);
+  color: hsl(0, 0%, 21%);
+}
+.tabs li {
+  display: block;
+}
+.tabs li.is-active a, .tabs .table-of-progress .step :hover li.number a, .table-of-progress .step :hover .tabs li.number a, .tabs .table-of-progress .step :hover li.is-active a, .table-of-progress .step :hover .tabs li.is-active a {
+  border-bottom-color: rgb(51, 51, 51);
+  color: rgb(51, 51, 51);
+}
+.tabs ul {
+  align-items: center;
+  border-bottom-color: rgb(216, 216, 216);
+  border-bottom-style: solid;
+  border-bottom-width: 2px;
+  display: flex;
+  flex-grow: 1;
+  flex-shrink: 0;
+  justify-content: flex-start;
+}
+.tabs ul.is-left {
+  padding-right: 0.75em;
+}
+.tabs ul.is-center {
+  flex: none;
+  justify-content: center;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+}
+.tabs ul.is-right {
+  justify-content: flex-end;
+  padding-left: 0.75em;
+}
+.tabs .icon:first-child {
+  margin-right: 0.5em;
+}
+.tabs .icon:last-child {
+  margin-left: 0.5em;
+}
+.tabs.is-centered ul {
+  justify-content: center;
+}
+.tabs.is-right ul {
+  justify-content: flex-end;
+}
+.tabs.is-boxed a {
+  border: 1px solid transparent;
+  border-radius: 0 0 0 0;
+}
+.tabs.is-boxed a:hover {
+  background-color: rgb(255, 255, 255);
+  border-bottom-color: rgb(255, 255, 255);
+}
+.tabs.is-boxed li.is-active a, .tabs.is-boxed .table-of-progress .step :hover li.number a, .table-of-progress .step :hover .tabs.is-boxed li.number a, .tabs.is-boxed .table-of-progress .step :hover li.is-active a, .table-of-progress .step :hover .tabs.is-boxed li.is-active a {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(216, 216, 216);
+  border-bottom-color: transparent !important;
+}
+.tabs.is-fullwidth li {
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+.tabs.is-toggle a {
+  border-color: rgb(245, 245, 245);
+  border-style: solid;
+  border-width: 1px;
+  margin-bottom: 0;
+  position: relative;
+}
+.tabs.is-toggle a:hover {
+  background-color: hsl(0, 0%, 96%);
+  border-color: rgb(216, 216, 216);
+  z-index: 2;
+}
+.tabs.is-toggle li + li {
+  margin-left: -1px;
+}
+.tabs.is-toggle li:first-child a {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+.tabs.is-toggle li:last-child a {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+.tabs.is-toggle li.is-active a, .tabs.is-toggle .table-of-progress .step :hover li.number a, .table-of-progress .step :hover .tabs.is-toggle li.number a, .tabs.is-toggle .table-of-progress .step :hover li.is-active a, .table-of-progress .step :hover .tabs.is-toggle li.is-active a {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: #fff;
+  z-index: 1;
+}
+.tabs.is-toggle ul {
+  border-bottom: none;
+}
+.tabs.is-toggle.is-toggle-rounded li:first-child a {
+  border-bottom-left-radius: 290486px;
+  border-top-left-radius: 290486px;
+  padding-left: 1.25em;
+}
+.tabs.is-toggle.is-toggle-rounded li:last-child a {
+  border-bottom-right-radius: 290486px;
+  border-top-right-radius: 290486px;
+  padding-right: 1.25em;
+}
+.tabs.is-small {
+  font-size: 0.8rem;
+}
+.tabs.is-medium {
+  font-size: 1.12rem;
+}
+.tabs.is-large {
+  font-size: 1.43rem;
+}
+
+.tabs {
+  font-family: "Source Sans Pro", sans-serif;
+}
+.tabs a {
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 4px solid transparent;
+  margin: 0 1rem -2px 1rem;
+}
+.tabs a:hover {
+  border-bottom-color: rgb(51, 51, 51);
+}
+.tabs li:first-child a {
+  margin-left: 0;
+}
+.tabs li:last-child a {
+  margin-right: 0;
+}
+.tabs.is-boxed a {
+  margin: 0 0 -2px;
+  border: 2px solid rgb(216, 216, 216);
+  border-right: 0;
+  background-color: rgb(245, 245, 245);
+  font-size: 1rem;
+}
+.tabs.is-boxed li:last-child a {
+  border-right: 2px solid rgb(216, 216, 216);
+}
+
+.tabs-content {
+  margin-top: -1.5rem;
+  padding-top: 2rem;
+}
+.tabs-content .tabs-panel {
+  display: none;
+}
+.tabs-content .tabs-panel.is-active, .tabs-content .table-of-progress .step :hover .tabs-panel.number, .table-of-progress .step :hover .tabs-content .tabs-panel.number, .tabs-content .table-of-progress .step :hover .tabs-panel.is-active, .table-of-progress .step :hover .tabs-content .tabs-panel.is-active {
+  display: block;
+}
+.tabs-content.is-boxed {
+  border: 2px solid rgb(216, 216, 216);
+  border-top: 0;
+  background-color: rgb(255, 255, 255);
+}
+
+.notification .notification-container {
+  display: block;
+  position: relative;
+  width: 100%;
+  color: rgb(0, 0, 0);
+  border-radius: 0.25rem;
+}
+.notification .notification-container .icon-container {
+  position: absolute;
+  display: flex;
+  right: 3rem;
+  top: 0;
+  bottom: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin: auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border-width: 2px;
+  border-style: solid;
+}
+.notification.warning .notification-container {
+  padding: 3rem 6rem 3rem 3rem;
+  background-color: rgb(250, 236, 188);
+}
+.notification.warning .notification-container .icon-container {
+  color: rgb(242, 171, 32);
+  border-color: rgb(242, 171, 32);
+}
+.notification.warning .notification-container:hover .b-header, .notification.warning .notification-container:hover .table-of-progress .step-header, .table-of-progress .notification.warning .notification-container:hover .step-header {
+  text-decoration: underline;
+}
+@media screen and (max-width: 768px) {
+  .notification.warning .notification-container {
+    padding: 2rem;
+  }
+  .notification.warning .notification-container .icon-container {
+    display: none;
+  }
+}
+.notification.content .notification-container {
+  display: flex;
+  background-color: rgb(255, 255, 255);
+  border: 2px solid rgb(216, 216, 216);
+}
+.notification.content .notification-container .content-image img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem 0 0 0.25rem;
+}
+.notification.content .notification-container .content-wrap {
+  width: 100%;
+  padding: 3rem 6rem 3rem 3rem;
+}
+.notification.content .notification-container .content-wrap .icon-container {
+  color: rgb(176, 176, 176);
+  border-color: rgb(176, 176, 176);
+}
+.notification.content .notification-container:hover {
+  border: 2px solid rgb(176, 176, 176);
+  box-shadow: 0.5rem 0.5rem 0 rgba(0, 0, 0, 0.06);
+}
+@media screen and (max-width: 768px) {
+  .notification.content .notification-container .content-image {
+    display: none;
+  }
+  .notification.content .notification-container .content-wrap {
+    padding: 2rem;
+  }
+  .notification.content .notification-container .content-wrap .icon-container {
+    display: none;
+  }
+}
+.notification.is-compact .notification-container {
+  padding-left: 1.5rem;
+}
+.notification.is-compact .notification-container p {
+  font-weight: bold;
+  line-height: 1.5rem;
+  color: rgb(51, 51, 51);
+}
+
+.menu {
+  font-size: 1rem;
+}
+.menu.is-small {
+  font-size: 0.8rem;
+}
+.menu.is-medium {
+  font-size: 1.12rem;
+}
+.menu.is-large {
+  font-size: 1.43rem;
+}
+
+.menu-list {
+  line-height: 1.25;
+}
+.menu-list a {
+  border-radius: 2px;
+  color: rgb(226, 54, 0);
+  display: block;
+  padding: 0.5rem 0;
+}
+.menu-list a:hover {
+  background-color: none;
+  color: hsl(0, 0%, 21%);
+}
+.menu-list a.is-active, .menu-list .table-of-progress .step :hover a.number, .table-of-progress .step :hover .menu-list a.number, .menu-list .table-of-progress .step :hover a.is-active, .table-of-progress .step :hover .menu-list a.is-active {
+  background-color: none;
+  color: rgb(51, 51, 51);
+}
+.menu-list li ul {
+  border-left: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+.menu-label {
+  color: rgb(176, 176, 176);
+  font-size: 0.75em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.menu-label:not(:first-child) {
+  margin-top: 1em;
+}
+.menu-label:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.sidebar-menu {
+  font-weight: bold;
+  line-height: 1.5;
+  background-color: rgb(245, 245, 245);
+}
+.sidebar-menu .menu-list .link {
+  text-decoration: none;
+}
+.sidebar-menu .icon {
+  font-size: 0.375rem;
+}
+.sidebar-menu .divider {
+  border-top: 0.1875rem solid rgb(255, 255, 255);
+}
+
+.menu {
+  font-size: 1rem;
+}
+.menu.is-small {
+  font-size: 0.8rem;
+}
+.menu.is-medium {
+  font-size: 1.12rem;
+}
+.menu.is-large {
+  font-size: 1.43rem;
+}
+
+.menu-list {
+  line-height: 1.25;
+}
+.menu-list a {
+  border-radius: 2px;
+  color: rgb(226, 54, 0);
+  display: block;
+  padding: 0.5rem 0;
+}
+.menu-list a:hover {
+  background-color: none;
+  color: hsl(0, 0%, 21%);
+}
+.menu-list a.is-active, .menu-list .table-of-progress .step :hover a.number, .table-of-progress .step :hover .menu-list a.number, .menu-list .table-of-progress .step :hover a.is-active, .table-of-progress .step :hover .menu-list a.is-active {
+  background-color: none;
+  color: rgb(51, 51, 51);
+}
+.menu-list li ul {
+  border-left: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+.menu-label {
+  color: rgb(176, 176, 176);
+  font-size: 0.75em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.menu-label:not(:first-child) {
+  margin-top: 1em;
+}
+.menu-label:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.table-of-contents {
+  font-weight: bold;
+  line-height: 1.5;
+  border: 0.125rem solid rgb(245, 245, 245);
+  box-sizing: border-box;
+  background-color: rgb(255, 255, 255);
+}
+.table-of-contents .menu-list .link {
+  text-decoration: none;
+}
+.table-of-contents .icon {
+  font-size: 0.375rem;
+}
+
+.table-of-progress .step-header {
+  line-height: 1.6875;
+}
+.table-of-progress .step .link {
+  text-decoration: none;
+  line-height: 1.25;
+  font-weight: bold;
+}
+.table-of-progress .step .number, .table-of-progress .step .is-active, .table-of-progress .step :hover .number, .table-of-progress .step :hover .is-active {
+  background-color: rgb(245, 245, 245);
+  width: 1.8125rem;
+  height: 1.8125rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+.table-of-progress .step .is-active, .table-of-progress .step :hover .number, .table-of-progress .step :hover .is-active {
+  background-color: rgb(51, 51, 51);
+  color: rgb(255, 255, 255);
+  position: relative;
+}
+.table-of-progress .step:not(:last-of-type)::after {
+  content: "";
+  display: block;
+  height: 1.5rem;
+  border-left: 0.1875rem solid rgb(245, 245, 245);
+  margin-left: 0.8125rem;
+}
+
+.breadcrumb {
+  font-size: 1rem;
+  white-space: nowrap;
+}
+.breadcrumb a {
+  align-items: center;
+  color: rgb(226, 54, 0);
+  display: flex;
+  justify-content: center;
+  padding: 0 0.5rem;
+}
+.breadcrumb a:hover {
+  color: rgb(226, 54, 0);
+}
+.breadcrumb li {
+  align-items: center;
+  display: flex;
+}
+.breadcrumb li:first-child a {
+  padding-left: 0;
+}
+.breadcrumb li.is-active a, .breadcrumb .table-of-progress .step :hover li.number a, .table-of-progress .step :hover .breadcrumb li.number a, .breadcrumb .table-of-progress .step :hover li.is-active a, .table-of-progress .step :hover .breadcrumb li.is-active a {
+  color: rgb(51, 51, 51);
+  cursor: default;
+  pointer-events: none;
+}
+.breadcrumb li + li::before {
+  color: rgb(176, 176, 176);
+  content: "/";
+}
+.breadcrumb ul,
+.breadcrumb ol {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+.breadcrumb .icon:first-child {
+  margin-right: 0.5em;
+}
+.breadcrumb .icon:last-child {
+  margin-left: 0.5em;
+}
+.breadcrumb.is-centered ol,
+.breadcrumb.is-centered ul {
+  justify-content: center;
+}
+.breadcrumb.is-right ol,
+.breadcrumb.is-right ul {
+  justify-content: flex-end;
+}
+.breadcrumb.is-small {
+  font-size: 0.8rem;
+}
+.breadcrumb.is-medium {
+  font-size: 1.12rem;
+}
+.breadcrumb.is-large {
+  font-size: 1.43rem;
+}
+.breadcrumb.has-arrow-separator li + li::before {
+  content: "→";
+}
+.breadcrumb.has-bullet-separator li + li::before {
+  content: "•";
+}
+.breadcrumb.has-dot-separator li + li::before {
+  content: "·";
+}
+.breadcrumb.has-succeeds-separator li + li::before {
+  content: "≻";
+}
+
+nav.breadcrumb > ul {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+nav.breadcrumb > ul li + li:before {
+  font-family: "Vocabulary Icons";
+  content: "\e901";
+}
+nav.breadcrumb > ul li:hover {
+  text-underline-position: below;
+}
+
+.pagination {
+  font-size: 1rem;
+  margin: -0.25rem;
+}
+.pagination.is-small {
+  font-size: 0.8rem;
+}
+.pagination.is-medium {
+  font-size: 1.12rem;
+}
+.pagination.is-large {
+  font-size: 1.43rem;
+}
+.pagination.is-rounded .pagination-previous, .image .pagination.profile .pagination-previous,
+.pagination.is-rounded .pagination-next,
+.image .pagination.profile .pagination-next {
+  padding-left: 1em;
+  padding-right: 1em;
+  border-radius: 290486px;
+}
+.pagination.is-rounded .pagination-link, .image .pagination.profile .pagination-link {
+  border-radius: 290486px;
+}
+
+.pagination,
+.pagination-list {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+}
+
+.pagination-previous,
+.pagination-next,
+.pagination-link,
+.pagination-ellipsis {
+  font-size: 1.25rem;
+  justify-content: center;
+  margin: 0.25rem;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  text-align: center;
+}
+
+.pagination-previous,
+.pagination-next,
+.pagination-link {
+  border-color: rgb(245, 245, 245);
+  color: rgb(118, 118, 118);
+  min-width: 2.5em;
+}
+.pagination-previous:hover,
+.pagination-next:hover,
+.pagination-link:hover {
+  border-color: rgb(118, 118, 118);
+  color: rgb(255, 255, 255);
+}
+.pagination-previous:focus,
+.pagination-next:focus,
+.pagination-link:focus {
+  border-color: rgb(60, 92, 153);
+}
+.pagination-previous:active,
+.pagination-next:active,
+.pagination-link:active {
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.pagination-previous[disabled],
+.pagination-next[disabled],
+.pagination-link[disabled] {
+  background-color: rgb(245, 245, 245);
+  border-color: rgb(245, 245, 245);
+  box-shadow: none;
+  color: rgb(176, 176, 176);
+  opacity: 0.5;
+}
+
+.pagination-previous,
+.pagination-next {
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  white-space: nowrap;
+}
+
+.pagination-link.is-current {
+  background-color: rgb(118, 118, 118);
+  border-color: rgb(118, 118, 118);
+  color: rgb(255, 255, 255);
+}
+
+.pagination-ellipsis {
+  color: rgb(118, 118, 118);
+  pointer-events: none;
+}
+
+.pagination-list {
+  flex-wrap: wrap;
+}
+
+@media screen and (max-width: 768px) {
+  .pagination {
+    flex-wrap: wrap;
+  }
+  .pagination-previous,
+  .pagination-next {
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+  .pagination-list li {
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .pagination-list {
+    flex-grow: 1;
+    flex-shrink: 1;
+    justify-content: flex-start;
+    order: 1;
+  }
+  .pagination-previous {
+    order: 2;
+  }
+  .pagination-next {
+    order: 3;
+  }
+  .pagination {
+    justify-content: space-between;
+  }
+  .pagination.is-centered .pagination-previous {
+    order: 1;
+  }
+  .pagination.is-centered .pagination-list {
+    justify-content: center;
+    order: 2;
+  }
+  .pagination.is-centered .pagination-next {
+    order: 3;
+  }
+  .pagination.is-right .pagination-previous {
+    order: 1;
+  }
+  .pagination.is-right .pagination-next {
+    order: 2;
+  }
+  .pagination.is-right .pagination-list {
+    justify-content: flex-end;
+    order: 3;
+  }
+}
+.pagination .pagination-list .common, .pagination .pagination-list .inactive-grey, .pagination .pagination-list .inactive {
+  font-weight: bold;
+  font-family: "Roboto Condensed", sans-serif;
+  line-height: 1.875;
+}
+.pagination .pagination-list .common .common-link, .pagination .pagination-list .inactive-grey .common-link, .pagination .pagination-list .inactive-grey .inactive-link, .pagination .pagination-list .inactive .common-link, .pagination .pagination-list .inactive .inactive-link {
+  border-radius: 0;
+  text-decoration: none;
+}
+.pagination .pagination-list .inactive .inactive-link {
+  background-color: rgb(245, 245, 245);
+}
+.pagination .pagination-list .inactive :hover {
+  background-color: rgb(118, 118, 118);
+}
+.pagination .pagination-list .inactive-grey .inactive-link {
+  background-color: rgb(255, 255, 255);
+}
+.pagination .pagination-list .inactive-grey :hover {
+  background-color: rgb(118, 118, 118);
+}
+
+.level {
+  align-items: center;
+  justify-content: space-between;
+}
+.level code {
+  border-radius: 4px;
+}
+.level img {
+  display: inline-block;
+  vertical-align: top;
+}
+.level.is-mobile {
+  display: flex;
+}
+.level.is-mobile .level-left,
+.level.is-mobile .level-right {
+  display: flex;
+}
+.level.is-mobile .level-left + .level-right {
+  margin-top: 0;
+}
+.level.is-mobile .level-item:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 0.75rem;
+}
+.level.is-mobile .level-item:not(.is-narrow) {
+  flex-grow: 1;
+}
+@media screen and (min-width: 769px), print {
+  .level {
+    display: flex;
+  }
+  .level > .level-item:not(.is-narrow) {
+    flex-grow: 1;
+  }
+}
+
+.level-item {
+  align-items: center;
+  display: flex;
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+  justify-content: center;
+}
+.level-item .title,
+.level-item .subtitle {
+  margin-bottom: 0;
+}
+@media screen and (max-width: 768px) {
+  .level-item:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+}
+
+.level-left,
+.level-right {
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+.level-left .level-item.is-flexible,
+.level-right .level-item.is-flexible {
+  flex-grow: 1;
+}
+@media screen and (min-width: 769px), print {
+  .level-left .level-item:not(:last-child),
+  .level-right .level-item:not(:last-child) {
+    margin-right: 0.75rem;
+  }
+}
+
+.level-left {
+  align-items: center;
+  justify-content: flex-start;
+}
+@media screen and (max-width: 768px) {
+  .level-left + .level-right {
+    margin-top: 1.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .level-left {
+    display: flex;
+  }
+}
+
+.level-right {
+  align-items: center;
+  justify-content: flex-end;
+}
+@media screen and (min-width: 769px), print {
+  .level-right {
+    display: flex;
+  }
+}
+
+.cc-global-header {
+  position: relative;
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+  z-index: 90;
+}
+.cc-global-header.is-active .global-header-content, .table-of-progress .step :hover .cc-global-header.number .global-header-content, .table-of-progress .step :hover .cc-global-header.is-active .global-header-content {
+  max-height: 60rem;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+.cc-global-header .open-tab {
+  position: absolute;
+  padding: 0.5rem 1rem;
+  right: 0;
+  bottom: -2rem;
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+  border-radius: 0 0 0.25rem 0.25rem;
+}
+.cc-global-header .global-header-content {
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  overflow: hidden;
+  transition: all 1s ease;
+}
+.cc-global-header .global-header-content .global-header-header {
+  padding-top: 1rem;
+}
+.cc-global-header .global-header-content .global-header-header .main-logo svg {
+  width: 16rem;
+}
+.cc-global-header .global-header-content .donate-section h5 {
+  color: rgb(255, 255, 255);
+}
+.cc-global-header .global-header-content .donate-section .donate {
+  margin-top: 1.5rem;
+  color: rgb(0, 0, 0);
+}
+.cc-global-header .global-header-content .donate-section .donate svg {
+  margin-right: 1rem;
+  width: 2rem;
+  height: 2rem;
+}
+.cc-global-header .global-header-content .products {
+  padding-bottom: 1rem;
+}
+.cc-global-header .global-header-content .products .product-list {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(3, auto);
+  width: 100%;
+}
+.cc-global-header .global-header-content .products .product-list .product-item {
+  flex-direction: column;
+  align-items: flex-start;
+  flex-shrink: 1;
+  color: rgb(255, 255, 255);
+}
+.cc-global-header .global-header-content .products .product-list .product-item strong {
+  display: flex;
+  color: rgb(5, 181, 218);
+  line-height: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+.cc-global-header .global-header-content .products .product-list .product-item strong:after {
+  content: "";
+  display: inline-block;
+  width: 1.2rem;
+  height: 1.2rem;
+  margin-left: 0.5rem;
+  background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 6C7.55228 6 8 5.55228 8 5C8 4.44772 7.55228 4 7 4L7 6ZM17 13C17 12.4477 16.5523 12 16 12C15.4477 12 15 12.4477 15 13H17ZM7 4L4 4L4 6L7 6L7 4ZM2 6V16H4V6H2ZM4 18H15V16H4V18ZM17 16V13H15V16H17ZM15 18C16.1046 18 17 17.1046 17 16H15H15V18ZM2 16C2 17.1046 2.89543 18 4 18V16L4 16H2ZM4 4C2.89543 4 2 4.89543 2 6H4L4 6L4 4Z' fill='%2305B5DA'/%3E%3Cpath d='M8.29289 10.2656C7.90237 10.6562 7.90237 11.2893 8.29289 11.6798C8.68342 12.0704 9.31658 12.0704 9.70711 11.6798L8.29289 10.2656ZM16.9727 3H17.9727V2H16.9727V3ZM15.9727 9C15.9727 9.55228 16.4205 10 16.9727 10C17.525 10 17.9727 9.55228 17.9727 9H15.9727ZM11 2C10.4477 2 10 2.44772 10 3C10 3.55228 10.4477 4 11 4V2ZM9.70711 11.6798L17.6799 3.70711L16.2656 2.29289L8.29289 10.2656L9.70711 11.6798ZM15.9727 3V9H17.9727V3H15.9727ZM16.9727 2H11V4H16.9727V2Z' fill='%2305B5DA'/%3E%3C/svg%3E%0A");
+}
+.cc-global-header .global-header-content .products .product-list .product-item:hover strong {
+  text-decoration: underline;
+}
+@media screen and (min-width: 769px), print {
+  .cc-global-header {
+    padding: 0 1.5rem;
+  }
+}
+@media screen and (max-width: 768px) {
+  .cc-global-header {
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
+  .cc-global-header .global-header-header .main-logo svg {
+    width: 14rem;
+  }
+  .cc-global-header .global-header-header {
+    text-align: center;
+  }
+  .cc-global-header .donate-section {
+    text-align: center;
+  }
+  .cc-global-header .donate-section h5 {
+    line-height: 2rem;
+  }
+  .cc-global-header .donate-section .donate {
+    margin-top: 0.5rem;
+  }
+  .cc-global-header .products .product-list {
+    grid-template-columns: repeat(2, auto);
+  }
+}
+
+.navbar {
+  background-color: rgb(255, 255, 255);
+  min-height: 3.25rem;
+  position: relative;
+  z-index: 30;
+}
+.navbar.is-white {
+  background-color: rgb(255, 255, 255);
+  color: rgb(0, 0, 0);
+}
+.navbar.is-white .navbar-brand > .navbar-item,
+.navbar.is-white .navbar-brand .navbar-link {
+  color: rgb(0, 0, 0);
+}
+.navbar.is-white .navbar-brand > a.navbar-item:focus, .navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active, .navbar.is-white .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-white .navbar-brand > a.navbar-item.number,
+.navbar.is-white .navbar-brand .navbar-link:focus,
+.navbar.is-white .navbar-brand .navbar-link:hover,
+.navbar.is-white .navbar-brand .navbar-link.is-active,
+.navbar.is-white .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-white .navbar-brand .navbar-link.number {
+  background-color: #f2f2f2;
+  color: rgb(0, 0, 0);
+}
+.navbar.is-white .navbar-brand .navbar-link::after {
+  border-color: rgb(0, 0, 0);
+}
+.navbar.is-white .navbar-burger {
+  color: rgb(0, 0, 0);
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-white .navbar-start > .navbar-item,
+  .navbar.is-white .navbar-start .navbar-link,
+  .navbar.is-white .navbar-end > .navbar-item,
+  .navbar.is-white .navbar-end .navbar-link {
+    color: rgb(0, 0, 0);
+  }
+  .navbar.is-white .navbar-start > a.navbar-item:focus, .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active, .navbar.is-white .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-white .navbar-start > a.navbar-item.number,
+  .navbar.is-white .navbar-start .navbar-link:focus,
+  .navbar.is-white .navbar-start .navbar-link:hover,
+  .navbar.is-white .navbar-start .navbar-link.is-active,
+  .navbar.is-white .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-white .navbar-start .navbar-link.number,
+  .navbar.is-white .navbar-end > a.navbar-item:focus,
+  .navbar.is-white .navbar-end > a.navbar-item:hover,
+  .navbar.is-white .navbar-end > a.navbar-item.is-active,
+  .navbar.is-white .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-white .navbar-end > a.navbar-item.number,
+  .navbar.is-white .navbar-end .navbar-link:focus,
+  .navbar.is-white .navbar-end .navbar-link:hover,
+  .navbar.is-white .navbar-end .navbar-link.is-active,
+  .navbar.is-white .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-white .navbar-end .navbar-link.number {
+    background-color: #f2f2f2;
+    color: rgb(0, 0, 0);
+  }
+  .navbar.is-white .navbar-start .navbar-link::after,
+  .navbar.is-white .navbar-end .navbar-link::after {
+    border-color: rgb(0, 0, 0);
+  }
+  .navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-white .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-white .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #f2f2f2;
+    color: rgb(0, 0, 0);
+  }
+  .navbar.is-white .navbar-dropdown a.navbar-item.is-active, .navbar.is-white .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-white .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(255, 255, 255);
+    color: rgb(0, 0, 0);
+  }
+}
+.navbar.is-black {
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+}
+.navbar.is-black .navbar-brand > .navbar-item,
+.navbar.is-black .navbar-brand .navbar-link {
+  color: rgb(255, 255, 255);
+}
+.navbar.is-black .navbar-brand > a.navbar-item:focus, .navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active, .navbar.is-black .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-black .navbar-brand > a.navbar-item.number,
+.navbar.is-black .navbar-brand .navbar-link:focus,
+.navbar.is-black .navbar-brand .navbar-link:hover,
+.navbar.is-black .navbar-brand .navbar-link.is-active,
+.navbar.is-black .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-black .navbar-brand .navbar-link.number {
+  background-color: black;
+  color: rgb(255, 255, 255);
+}
+.navbar.is-black .navbar-brand .navbar-link::after {
+  border-color: rgb(255, 255, 255);
+}
+.navbar.is-black .navbar-burger {
+  color: rgb(255, 255, 255);
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-black .navbar-start > .navbar-item,
+  .navbar.is-black .navbar-start .navbar-link,
+  .navbar.is-black .navbar-end > .navbar-item,
+  .navbar.is-black .navbar-end .navbar-link {
+    color: rgb(255, 255, 255);
+  }
+  .navbar.is-black .navbar-start > a.navbar-item:focus, .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active, .navbar.is-black .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-black .navbar-start > a.navbar-item.number,
+  .navbar.is-black .navbar-start .navbar-link:focus,
+  .navbar.is-black .navbar-start .navbar-link:hover,
+  .navbar.is-black .navbar-start .navbar-link.is-active,
+  .navbar.is-black .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-black .navbar-start .navbar-link.number,
+  .navbar.is-black .navbar-end > a.navbar-item:focus,
+  .navbar.is-black .navbar-end > a.navbar-item:hover,
+  .navbar.is-black .navbar-end > a.navbar-item.is-active,
+  .navbar.is-black .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-black .navbar-end > a.navbar-item.number,
+  .navbar.is-black .navbar-end .navbar-link:focus,
+  .navbar.is-black .navbar-end .navbar-link:hover,
+  .navbar.is-black .navbar-end .navbar-link.is-active,
+  .navbar.is-black .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-black .navbar-end .navbar-link.number {
+    background-color: black;
+    color: rgb(255, 255, 255);
+  }
+  .navbar.is-black .navbar-start .navbar-link::after,
+  .navbar.is-black .navbar-end .navbar-link::after {
+    border-color: rgb(255, 255, 255);
+  }
+  .navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-black .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-black .navbar-item.has-dropdown.number .navbar-link {
+    background-color: black;
+    color: rgb(255, 255, 255);
+  }
+  .navbar.is-black .navbar-dropdown a.navbar-item.is-active, .navbar.is-black .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-black .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(0, 0, 0);
+    color: rgb(255, 255, 255);
+  }
+}
+.navbar.is-light {
+  background-color: hsl(0, 0%, 96%);
+  color: rgba(0, 0, 0, 0.7);
+}
+.navbar.is-light .navbar-brand > .navbar-item,
+.navbar.is-light .navbar-brand .navbar-link {
+  color: rgba(0, 0, 0, 0.7);
+}
+.navbar.is-light .navbar-brand > a.navbar-item:focus, .navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active, .navbar.is-light .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-light .navbar-brand > a.navbar-item.number,
+.navbar.is-light .navbar-brand .navbar-link:focus,
+.navbar.is-light .navbar-brand .navbar-link:hover,
+.navbar.is-light .navbar-brand .navbar-link.is-active,
+.navbar.is-light .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-light .navbar-brand .navbar-link.number {
+  background-color: #e8e8e8;
+  color: rgba(0, 0, 0, 0.7);
+}
+.navbar.is-light .navbar-brand .navbar-link::after {
+  border-color: rgba(0, 0, 0, 0.7);
+}
+.navbar.is-light .navbar-burger {
+  color: rgba(0, 0, 0, 0.7);
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-light .navbar-start > .navbar-item,
+  .navbar.is-light .navbar-start .navbar-link,
+  .navbar.is-light .navbar-end > .navbar-item,
+  .navbar.is-light .navbar-end .navbar-link {
+    color: rgba(0, 0, 0, 0.7);
+  }
+  .navbar.is-light .navbar-start > a.navbar-item:focus, .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active, .navbar.is-light .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-light .navbar-start > a.navbar-item.number,
+  .navbar.is-light .navbar-start .navbar-link:focus,
+  .navbar.is-light .navbar-start .navbar-link:hover,
+  .navbar.is-light .navbar-start .navbar-link.is-active,
+  .navbar.is-light .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-light .navbar-start .navbar-link.number,
+  .navbar.is-light .navbar-end > a.navbar-item:focus,
+  .navbar.is-light .navbar-end > a.navbar-item:hover,
+  .navbar.is-light .navbar-end > a.navbar-item.is-active,
+  .navbar.is-light .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-light .navbar-end > a.navbar-item.number,
+  .navbar.is-light .navbar-end .navbar-link:focus,
+  .navbar.is-light .navbar-end .navbar-link:hover,
+  .navbar.is-light .navbar-end .navbar-link.is-active,
+  .navbar.is-light .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-light .navbar-end .navbar-link.number {
+    background-color: #e8e8e8;
+    color: rgba(0, 0, 0, 0.7);
+  }
+  .navbar.is-light .navbar-start .navbar-link::after,
+  .navbar.is-light .navbar-end .navbar-link::after {
+    border-color: rgba(0, 0, 0, 0.7);
+  }
+  .navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-light .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-light .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #e8e8e8;
+    color: rgba(0, 0, 0, 0.7);
+  }
+  .navbar.is-light .navbar-dropdown a.navbar-item.is-active, .navbar.is-light .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-light .navbar-dropdown a.navbar-item.number {
+    background-color: hsl(0, 0%, 96%);
+    color: rgba(0, 0, 0, 0.7);
+  }
+}
+.navbar.is-dark {
+  background-color: hsl(0, 0%, 21%);
+  color: #fff;
+}
+.navbar.is-dark .navbar-brand > .navbar-item,
+.navbar.is-dark .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-dark .navbar-brand > a.navbar-item:focus, .navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active, .navbar.is-dark .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-dark .navbar-brand > a.navbar-item.number,
+.navbar.is-dark .navbar-brand .navbar-link:focus,
+.navbar.is-dark .navbar-brand .navbar-link:hover,
+.navbar.is-dark .navbar-brand .navbar-link.is-active,
+.navbar.is-dark .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-dark .navbar-brand .navbar-link.number {
+  background-color: #292929;
+  color: #fff;
+}
+.navbar.is-dark .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-dark .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-dark .navbar-start > .navbar-item,
+  .navbar.is-dark .navbar-start .navbar-link,
+  .navbar.is-dark .navbar-end > .navbar-item,
+  .navbar.is-dark .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-dark .navbar-start > a.navbar-item:focus, .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active, .navbar.is-dark .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-dark .navbar-start > a.navbar-item.number,
+  .navbar.is-dark .navbar-start .navbar-link:focus,
+  .navbar.is-dark .navbar-start .navbar-link:hover,
+  .navbar.is-dark .navbar-start .navbar-link.is-active,
+  .navbar.is-dark .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-dark .navbar-start .navbar-link.number,
+  .navbar.is-dark .navbar-end > a.navbar-item:focus,
+  .navbar.is-dark .navbar-end > a.navbar-item:hover,
+  .navbar.is-dark .navbar-end > a.navbar-item.is-active,
+  .navbar.is-dark .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-dark .navbar-end > a.navbar-item.number,
+  .navbar.is-dark .navbar-end .navbar-link:focus,
+  .navbar.is-dark .navbar-end .navbar-link:hover,
+  .navbar.is-dark .navbar-end .navbar-link.is-active,
+  .navbar.is-dark .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-dark .navbar-end .navbar-link.number {
+    background-color: #292929;
+    color: #fff;
+  }
+  .navbar.is-dark .navbar-start .navbar-link::after,
+  .navbar.is-dark .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-dark .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-dark .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #292929;
+    color: #fff;
+  }
+  .navbar.is-dark .navbar-dropdown a.navbar-item.is-active, .navbar.is-dark .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-dark .navbar-dropdown a.navbar-item.number {
+    background-color: hsl(0, 0%, 21%);
+    color: #fff;
+  }
+}
+.navbar.is-primary {
+  background-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.navbar.is-primary .navbar-brand > .navbar-item,
+.navbar.is-primary .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-primary .navbar-brand > a.navbar-item:focus, .navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active, .navbar.is-primary .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-primary .navbar-brand > a.navbar-item.number,
+.navbar.is-primary .navbar-brand .navbar-link:focus,
+.navbar.is-primary .navbar-brand .navbar-link:hover,
+.navbar.is-primary .navbar-brand .navbar-link.is-active,
+.navbar.is-primary .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-primary .navbar-brand .navbar-link.number {
+  background-color: #c93000;
+  color: #fff;
+}
+.navbar.is-primary .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-primary .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-primary .navbar-start > .navbar-item,
+  .navbar.is-primary .navbar-start .navbar-link,
+  .navbar.is-primary .navbar-end > .navbar-item,
+  .navbar.is-primary .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-primary .navbar-start > a.navbar-item:focus, .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active, .navbar.is-primary .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-primary .navbar-start > a.navbar-item.number,
+  .navbar.is-primary .navbar-start .navbar-link:focus,
+  .navbar.is-primary .navbar-start .navbar-link:hover,
+  .navbar.is-primary .navbar-start .navbar-link.is-active,
+  .navbar.is-primary .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-primary .navbar-start .navbar-link.number,
+  .navbar.is-primary .navbar-end > a.navbar-item:focus,
+  .navbar.is-primary .navbar-end > a.navbar-item:hover,
+  .navbar.is-primary .navbar-end > a.navbar-item.is-active,
+  .navbar.is-primary .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-primary .navbar-end > a.navbar-item.number,
+  .navbar.is-primary .navbar-end .navbar-link:focus,
+  .navbar.is-primary .navbar-end .navbar-link:hover,
+  .navbar.is-primary .navbar-end .navbar-link.is-active,
+  .navbar.is-primary .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-primary .navbar-end .navbar-link.number {
+    background-color: #c93000;
+    color: #fff;
+  }
+  .navbar.is-primary .navbar-start .navbar-link::after,
+  .navbar.is-primary .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-primary .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-primary .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #c93000;
+    color: #fff;
+  }
+  .navbar.is-primary .navbar-dropdown a.navbar-item.is-active, .navbar.is-primary .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-primary .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(226, 54, 0);
+    color: #fff;
+  }
+}
+.navbar.is-link {
+  background-color: rgb(226, 54, 0);
+  color: #fff;
+}
+.navbar.is-link .navbar-brand > .navbar-item,
+.navbar.is-link .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-link .navbar-brand > a.navbar-item:focus, .navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active, .navbar.is-link .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-link .navbar-brand > a.navbar-item.number,
+.navbar.is-link .navbar-brand .navbar-link:focus,
+.navbar.is-link .navbar-brand .navbar-link:hover,
+.navbar.is-link .navbar-brand .navbar-link.is-active,
+.navbar.is-link .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-link .navbar-brand .navbar-link.number {
+  background-color: #c93000;
+  color: #fff;
+}
+.navbar.is-link .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-link .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-link .navbar-start > .navbar-item,
+  .navbar.is-link .navbar-start .navbar-link,
+  .navbar.is-link .navbar-end > .navbar-item,
+  .navbar.is-link .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-link .navbar-start > a.navbar-item:focus, .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active, .navbar.is-link .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-link .navbar-start > a.navbar-item.number,
+  .navbar.is-link .navbar-start .navbar-link:focus,
+  .navbar.is-link .navbar-start .navbar-link:hover,
+  .navbar.is-link .navbar-start .navbar-link.is-active,
+  .navbar.is-link .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-link .navbar-start .navbar-link.number,
+  .navbar.is-link .navbar-end > a.navbar-item:focus,
+  .navbar.is-link .navbar-end > a.navbar-item:hover,
+  .navbar.is-link .navbar-end > a.navbar-item.is-active,
+  .navbar.is-link .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-link .navbar-end > a.navbar-item.number,
+  .navbar.is-link .navbar-end .navbar-link:focus,
+  .navbar.is-link .navbar-end .navbar-link:hover,
+  .navbar.is-link .navbar-end .navbar-link.is-active,
+  .navbar.is-link .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-link .navbar-end .navbar-link.number {
+    background-color: #c93000;
+    color: #fff;
+  }
+  .navbar.is-link .navbar-start .navbar-link::after,
+  .navbar.is-link .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-link .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-link .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #c93000;
+    color: #fff;
+  }
+  .navbar.is-link .navbar-dropdown a.navbar-item.is-active, .navbar.is-link .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-link .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(226, 54, 0);
+    color: #fff;
+  }
+}
+.navbar.is-info {
+  background-color: rgb(25, 80, 184);
+  color: #fff;
+}
+.navbar.is-info .navbar-brand > .navbar-item,
+.navbar.is-info .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-info .navbar-brand > a.navbar-item:focus, .navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active, .navbar.is-info .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-info .navbar-brand > a.navbar-item.number,
+.navbar.is-info .navbar-brand .navbar-link:focus,
+.navbar.is-info .navbar-brand .navbar-link:hover,
+.navbar.is-info .navbar-brand .navbar-link.is-active,
+.navbar.is-info .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-info .navbar-brand .navbar-link.number {
+  background-color: #1646a2;
+  color: #fff;
+}
+.navbar.is-info .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-info .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-info .navbar-start > .navbar-item,
+  .navbar.is-info .navbar-start .navbar-link,
+  .navbar.is-info .navbar-end > .navbar-item,
+  .navbar.is-info .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-info .navbar-start > a.navbar-item:focus, .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active, .navbar.is-info .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-info .navbar-start > a.navbar-item.number,
+  .navbar.is-info .navbar-start .navbar-link:focus,
+  .navbar.is-info .navbar-start .navbar-link:hover,
+  .navbar.is-info .navbar-start .navbar-link.is-active,
+  .navbar.is-info .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-info .navbar-start .navbar-link.number,
+  .navbar.is-info .navbar-end > a.navbar-item:focus,
+  .navbar.is-info .navbar-end > a.navbar-item:hover,
+  .navbar.is-info .navbar-end > a.navbar-item.is-active,
+  .navbar.is-info .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-info .navbar-end > a.navbar-item.number,
+  .navbar.is-info .navbar-end .navbar-link:focus,
+  .navbar.is-info .navbar-end .navbar-link:hover,
+  .navbar.is-info .navbar-end .navbar-link.is-active,
+  .navbar.is-info .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-info .navbar-end .navbar-link.number {
+    background-color: #1646a2;
+    color: #fff;
+  }
+  .navbar.is-info .navbar-start .navbar-link::after,
+  .navbar.is-info .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-info .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-info .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #1646a2;
+    color: #fff;
+  }
+  .navbar.is-info .navbar-dropdown a.navbar-item.is-active, .navbar.is-info .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-info .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(25, 80, 184);
+    color: #fff;
+  }
+}
+.navbar.is-success {
+  background-color: rgb(0, 131, 0);
+  color: #fff;
+}
+.navbar.is-success .navbar-brand > .navbar-item,
+.navbar.is-success .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-success .navbar-brand > a.navbar-item:focus, .navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active, .navbar.is-success .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-success .navbar-brand > a.navbar-item.number,
+.navbar.is-success .navbar-brand .navbar-link:focus,
+.navbar.is-success .navbar-brand .navbar-link:hover,
+.navbar.is-success .navbar-brand .navbar-link.is-active,
+.navbar.is-success .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-success .navbar-brand .navbar-link.number {
+  background-color: #006a00;
+  color: #fff;
+}
+.navbar.is-success .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-success .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-success .navbar-start > .navbar-item,
+  .navbar.is-success .navbar-start .navbar-link,
+  .navbar.is-success .navbar-end > .navbar-item,
+  .navbar.is-success .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-success .navbar-start > a.navbar-item:focus, .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active, .navbar.is-success .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-success .navbar-start > a.navbar-item.number,
+  .navbar.is-success .navbar-start .navbar-link:focus,
+  .navbar.is-success .navbar-start .navbar-link:hover,
+  .navbar.is-success .navbar-start .navbar-link.is-active,
+  .navbar.is-success .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-success .navbar-start .navbar-link.number,
+  .navbar.is-success .navbar-end > a.navbar-item:focus,
+  .navbar.is-success .navbar-end > a.navbar-item:hover,
+  .navbar.is-success .navbar-end > a.navbar-item.is-active,
+  .navbar.is-success .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-success .navbar-end > a.navbar-item.number,
+  .navbar.is-success .navbar-end .navbar-link:focus,
+  .navbar.is-success .navbar-end .navbar-link:hover,
+  .navbar.is-success .navbar-end .navbar-link.is-active,
+  .navbar.is-success .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-success .navbar-end .navbar-link.number {
+    background-color: #006a00;
+    color: #fff;
+  }
+  .navbar.is-success .navbar-start .navbar-link::after,
+  .navbar.is-success .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-success .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-success .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #006a00;
+    color: #fff;
+  }
+  .navbar.is-success .navbar-dropdown a.navbar-item.is-active, .navbar.is-success .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-success .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(0, 131, 0);
+    color: #fff;
+  }
+}
+.navbar.is-warning {
+  background-color: rgb(242, 171, 32);
+  color: #fff;
+}
+.navbar.is-warning .navbar-brand > .navbar-item,
+.navbar.is-warning .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-warning .navbar-brand > a.navbar-item:focus, .navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active, .navbar.is-warning .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-warning .navbar-brand > a.navbar-item.number,
+.navbar.is-warning .navbar-brand .navbar-link:focus,
+.navbar.is-warning .navbar-brand .navbar-link:hover,
+.navbar.is-warning .navbar-brand .navbar-link.is-active,
+.navbar.is-warning .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-warning .navbar-brand .navbar-link.number {
+  background-color: #eba00e;
+  color: #fff;
+}
+.navbar.is-warning .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-warning .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-warning .navbar-start > .navbar-item,
+  .navbar.is-warning .navbar-start .navbar-link,
+  .navbar.is-warning .navbar-end > .navbar-item,
+  .navbar.is-warning .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-warning .navbar-start > a.navbar-item:focus, .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active, .navbar.is-warning .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-warning .navbar-start > a.navbar-item.number,
+  .navbar.is-warning .navbar-start .navbar-link:focus,
+  .navbar.is-warning .navbar-start .navbar-link:hover,
+  .navbar.is-warning .navbar-start .navbar-link.is-active,
+  .navbar.is-warning .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-warning .navbar-start .navbar-link.number,
+  .navbar.is-warning .navbar-end > a.navbar-item:focus,
+  .navbar.is-warning .navbar-end > a.navbar-item:hover,
+  .navbar.is-warning .navbar-end > a.navbar-item.is-active,
+  .navbar.is-warning .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-warning .navbar-end > a.navbar-item.number,
+  .navbar.is-warning .navbar-end .navbar-link:focus,
+  .navbar.is-warning .navbar-end .navbar-link:hover,
+  .navbar.is-warning .navbar-end .navbar-link.is-active,
+  .navbar.is-warning .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-warning .navbar-end .navbar-link.number {
+    background-color: #eba00e;
+    color: #fff;
+  }
+  .navbar.is-warning .navbar-start .navbar-link::after,
+  .navbar.is-warning .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-warning .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-warning .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #eba00e;
+    color: #fff;
+  }
+  .navbar.is-warning .navbar-dropdown a.navbar-item.is-active, .navbar.is-warning .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-warning .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(242, 171, 32);
+    color: #fff;
+  }
+}
+.navbar.is-danger {
+  background-color: rgb(200, 59, 30);
+  color: #fff;
+}
+.navbar.is-danger .navbar-brand > .navbar-item,
+.navbar.is-danger .navbar-brand .navbar-link {
+  color: #fff;
+}
+.navbar.is-danger .navbar-brand > a.navbar-item:focus, .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active, .navbar.is-danger .table-of-progress .step :hover .navbar-brand > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-danger .navbar-brand > a.navbar-item.number,
+.navbar.is-danger .navbar-brand .navbar-link:focus,
+.navbar.is-danger .navbar-brand .navbar-link:hover,
+.navbar.is-danger .navbar-brand .navbar-link.is-active,
+.navbar.is-danger .navbar-brand .table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar.is-danger .navbar-brand .navbar-link.number {
+  background-color: #b2341b;
+  color: #fff;
+}
+.navbar.is-danger .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+.navbar.is-danger .navbar-burger {
+  color: #fff;
+}
+@media screen and (min-width: 1024px) {
+  .navbar.is-danger .navbar-start > .navbar-item,
+  .navbar.is-danger .navbar-start .navbar-link,
+  .navbar.is-danger .navbar-end > .navbar-item,
+  .navbar.is-danger .navbar-end .navbar-link {
+    color: #fff;
+  }
+  .navbar.is-danger .navbar-start > a.navbar-item:focus, .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active, .navbar.is-danger .table-of-progress .step :hover .navbar-start > a.navbar-item.number, .table-of-progress .step :hover .navbar.is-danger .navbar-start > a.navbar-item.number,
+  .navbar.is-danger .navbar-start .navbar-link:focus,
+  .navbar.is-danger .navbar-start .navbar-link:hover,
+  .navbar.is-danger .navbar-start .navbar-link.is-active,
+  .navbar.is-danger .navbar-start .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-danger .navbar-start .navbar-link.number,
+  .navbar.is-danger .navbar-end > a.navbar-item:focus,
+  .navbar.is-danger .navbar-end > a.navbar-item:hover,
+  .navbar.is-danger .navbar-end > a.navbar-item.is-active,
+  .navbar.is-danger .table-of-progress .step :hover .navbar-end > a.navbar-item.number,
+  .table-of-progress .step :hover .navbar.is-danger .navbar-end > a.navbar-item.number,
+  .navbar.is-danger .navbar-end .navbar-link:focus,
+  .navbar.is-danger .navbar-end .navbar-link:hover,
+  .navbar.is-danger .navbar-end .navbar-link.is-active,
+  .navbar.is-danger .navbar-end .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-danger .navbar-end .navbar-link.number {
+    background-color: #b2341b;
+    color: #fff;
+  }
+  .navbar.is-danger .navbar-start .navbar-link::after,
+  .navbar.is-danger .navbar-end .navbar-link::after {
+    border-color: #fff;
+  }
+  .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
+  .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-danger .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link,
+  .table-of-progress .step :hover .navbar.is-danger .navbar-item.has-dropdown.number .navbar-link {
+    background-color: #b2341b;
+    color: #fff;
+  }
+  .navbar.is-danger .navbar-dropdown a.navbar-item.is-active, .navbar.is-danger .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-danger .navbar-dropdown a.navbar-item.number {
+    background-color: rgb(200, 59, 30);
+    color: #fff;
+  }
+}
+.navbar > .container {
+  align-items: stretch;
+  display: flex;
+  min-height: 3.25rem;
+  width: 100%;
+}
+.navbar.has-shadow {
+  box-shadow: 0 2px 0 0 hsl(0, 0%, 96%);
+}
+.navbar.is-fixed-bottom, .navbar.is-fixed-top {
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: 30;
+}
+.navbar.is-fixed-bottom {
+  bottom: 0;
+}
+.navbar.is-fixed-bottom.has-shadow {
+  box-shadow: 0 -2px 0 0 hsl(0, 0%, 96%);
+}
+.navbar.is-fixed-top {
+  top: 0;
+}
+
+html.has-navbar-fixed-top,
+body.has-navbar-fixed-top {
+  padding-top: 3.25rem;
+}
+html.has-navbar-fixed-bottom,
+body.has-navbar-fixed-bottom {
+  padding-bottom: 3.25rem;
+}
+
+.navbar-brand,
+.navbar-tabs {
+  align-items: stretch;
+  display: flex;
+  flex-shrink: 0;
+  min-height: 3.25rem;
+}
+
+.navbar-brand a.navbar-item:focus, .navbar-brand a.navbar-item:hover {
+  background-color: transparent;
+}
+
+.navbar-tabs {
+  -webkit-overflow-scrolling: touch;
+  max-width: 100vw;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.navbar-burger {
+  color: rgb(118, 118, 118);
+  cursor: pointer;
+  display: block;
+  height: 3.25rem;
+  position: relative;
+  width: 3.25rem;
+  margin-left: auto;
+}
+.navbar-burger span {
+  background-color: currentColor;
+  display: block;
+  height: 1px;
+  left: calc(50% - 8px);
+  position: absolute;
+  transform-origin: center;
+  transition-duration: 86ms;
+  transition-property: background-color, opacity, transform;
+  transition-timing-function: ease-out;
+  width: 16px;
+}
+.navbar-burger span:nth-child(1) {
+  top: calc(50% - 6px);
+}
+.navbar-burger span:nth-child(2) {
+  top: calc(50% - 1px);
+}
+.navbar-burger span:nth-child(3) {
+  top: calc(50% + 4px);
+}
+.navbar-burger:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.navbar-burger.is-active span:nth-child(1), .table-of-progress .step :hover .navbar-burger.number span:nth-child(1), .table-of-progress .step :hover .navbar-burger.is-active span:nth-child(1) {
+  transform: translateY(5px) rotate(45deg);
+}
+.navbar-burger.is-active span:nth-child(2), .table-of-progress .step :hover .navbar-burger.number span:nth-child(2), .table-of-progress .step :hover .navbar-burger.is-active span:nth-child(2) {
+  opacity: 0;
+}
+.navbar-burger.is-active span:nth-child(3), .table-of-progress .step :hover .navbar-burger.number span:nth-child(3), .table-of-progress .step :hover .navbar-burger.is-active span:nth-child(3) {
+  transform: translateY(-5px) rotate(-45deg);
+}
+
+.navbar-menu {
+  display: none;
+}
+
+.navbar-item,
+.navbar-link {
+  color: rgb(118, 118, 118);
+  display: block;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  position: relative;
+}
+.navbar-item .icon:only-child,
+.navbar-link .icon:only-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+a.navbar-item,
+.navbar-link {
+  cursor: pointer;
+}
+a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, a.navbar-item.is-active, .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover a.navbar-item.is-active,
+.navbar-link:focus,
+.navbar-link:focus-within,
+.navbar-link:hover,
+.navbar-link.is-active,
+.table-of-progress .step :hover .navbar-link.number,
+.table-of-progress .step :hover .navbar-link.is-active {
+  background-color: transparent;
+  color: rgb(51, 51, 51);
+}
+
+.navbar-item {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+.navbar-item img {
+  max-height: 1.75rem;
+}
+.navbar-item.has-dropdown {
+  padding: 0;
+}
+.navbar-item.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+.navbar-item.is-tab {
+  border-bottom: 1px solid transparent;
+  min-height: 3.25rem;
+  padding-bottom: calc(0.5rem - 1px);
+}
+.navbar-item.is-tab:focus, .navbar-item.is-tab:hover {
+  background-color: transparent;
+  border-bottom-color: rgb(226, 54, 0);
+}
+.navbar-item.is-tab.is-active, .table-of-progress .step :hover .navbar-item.is-tab.number, .table-of-progress .step :hover .navbar-item.is-tab.is-active {
+  background-color: transparent;
+  border-bottom-color: rgb(226, 54, 0);
+  border-bottom-style: solid;
+  border-bottom-width: 3px;
+  color: rgb(226, 54, 0);
+  padding-bottom: calc(0.5rem - 3px);
+}
+
+.navbar-content {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.navbar-link:not(.is-arrowless) {
+  padding-right: 2.5em;
+}
+.navbar-link:not(.is-arrowless)::after {
+  border-color: rgb(226, 54, 0);
+  margin-top: -0.375em;
+  right: 1.125em;
+}
+
+.navbar-dropdown {
+  font-size: 0.875rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+.navbar-dropdown .navbar-item {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.navbar-divider {
+  background-color: hsl(0, 0%, 96%);
+  border: none;
+  display: none;
+  height: 2px;
+  margin: 0.5rem 0;
+}
+
+@media screen and (max-width: 1023px) {
+  .navbar > .container {
+    display: block;
+  }
+  .navbar-brand .navbar-item,
+  .navbar-tabs .navbar-item {
+    align-items: center;
+    display: flex;
+  }
+  .navbar-link::after {
+    display: none;
+  }
+  .navbar-menu {
+    background-color: rgb(255, 255, 255);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    padding: 0.5rem 0;
+  }
+  .navbar-menu.is-active, .table-of-progress .step :hover .navbar-menu.number, .table-of-progress .step :hover .navbar-menu.is-active {
+    display: block;
+  }
+  .navbar.is-fixed-bottom-touch, .navbar.is-fixed-top-touch {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30;
+  }
+  .navbar.is-fixed-bottom-touch {
+    bottom: 0;
+  }
+  .navbar.is-fixed-bottom-touch.has-shadow {
+    box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.1);
+  }
+  .navbar.is-fixed-top-touch {
+    top: 0;
+  }
+  .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
+    -webkit-overflow-scrolling: touch;
+    max-height: calc(100vh - 3.25rem);
+    overflow: auto;
+  }
+  html.has-navbar-fixed-top-touch,
+  body.has-navbar-fixed-top-touch {
+    padding-top: 3.25rem;
+  }
+  html.has-navbar-fixed-bottom-touch,
+  body.has-navbar-fixed-bottom-touch {
+    padding-bottom: 3.25rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .navbar,
+  .navbar-menu,
+  .navbar-start,
+  .navbar-end {
+    align-items: stretch;
+    display: flex;
+  }
+  .navbar {
+    min-height: 3.25rem;
+  }
+  .navbar.is-spaced {
+    padding: 1rem 2rem;
+  }
+  .navbar.is-spaced .navbar-start,
+  .navbar.is-spaced .navbar-end {
+    align-items: center;
+  }
+  .navbar.is-spaced a.navbar-item,
+  .navbar.is-spaced .navbar-link {
+    border-radius: 4px;
+  }
+  .navbar.is-transparent a.navbar-item:focus, .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active, .navbar.is-transparent .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-transparent a.navbar-item.number,
+  .navbar.is-transparent .navbar-link:focus,
+  .navbar.is-transparent .navbar-link:hover,
+  .navbar.is-transparent .navbar-link.is-active,
+  .navbar.is-transparent .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar.is-transparent .navbar-link.number {
+    background-color: transparent !important;
+  }
+  .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link, .table-of-progress .step :hover .navbar.is-transparent .navbar-item.has-dropdown.number .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus-within .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+    background-color: transparent !important;
+  }
+  .navbar.is-transparent .navbar-dropdown a.navbar-item:focus, .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
+    background-color: hsl(0, 0%, 96%);
+    color: rgb(0, 0, 0);
+  }
+  .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active, .navbar.is-transparent .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar.is-transparent .navbar-dropdown a.navbar-item.number {
+    background-color: hsl(0, 0%, 96%);
+    color: rgb(226, 54, 0);
+  }
+  .navbar-burger {
+    display: none;
+  }
+  .navbar-item,
+  .navbar-link {
+    align-items: center;
+    display: flex;
+  }
+  .navbar-item.has-dropdown {
+    align-items: stretch;
+  }
+  .navbar-item.has-dropdown-up .navbar-link::after {
+    transform: rotate(135deg) translate(0.25em, -0.25em);
+  }
+  .navbar-item.has-dropdown-up .navbar-dropdown {
+    border-bottom: none;
+    border-radius: 0 0 0 0;
+    border-top: none;
+    bottom: 100%;
+    box-shadow: 0 -8px 8px rgba(0, 0, 0, 0.1);
+    top: auto;
+  }
+  .navbar-item.is-active .navbar-dropdown, .table-of-progress .step :hover .navbar-item.number .navbar-dropdown, .table-of-progress .step :hover .navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
+    display: block;
+  }
+  .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar.is-spaced .table-of-progress .step :hover .navbar-item.number .navbar-dropdown, .table-of-progress .step :hover .navbar.is-spaced .navbar-item.number .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .table-of-progress .step :hover .navbar-item.number .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+  .navbar-menu {
+    flex-grow: 1;
+    flex-shrink: 0;
+  }
+  .navbar-start {
+    justify-content: flex-start;
+    margin-right: auto;
+  }
+  .navbar-end {
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+  .navbar-dropdown {
+    background-color: rgb(255, 255, 255);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top: none;
+    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.1);
+    display: none;
+    font-size: 0.875rem;
+    left: 0;
+    min-width: 100%;
+    position: absolute;
+    top: 100%;
+    z-index: 20;
+  }
+  .navbar-dropdown .navbar-item {
+    padding: 0.375rem 1rem;
+    white-space: nowrap;
+  }
+  .navbar-dropdown a.navbar-item {
+    padding-right: 3rem;
+  }
+  .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
+    background-color: hsl(0, 0%, 96%);
+    color: rgb(0, 0, 0);
+  }
+  .navbar-dropdown a.navbar-item.is-active, .navbar-dropdown .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover .navbar-dropdown a.navbar-item.number, .navbar-dropdown .table-of-progress .step :hover a.navbar-item.is-active, .table-of-progress .step :hover .navbar-dropdown a.navbar-item.is-active {
+    background-color: hsl(0, 0%, 96%);
+    color: rgb(226, 54, 0);
+  }
+  .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
+    border-radius: 6px;
+    border-top: none;
+    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
+    display: block;
+    opacity: 0;
+    pointer-events: none;
+    top: calc(100% + (-4px));
+    transform: translateY(-5px);
+    transition-duration: 86ms;
+    transition-property: opacity, transform;
+  }
+  .navbar-dropdown.is-right {
+    left: auto;
+    right: 0;
+  }
+  .navbar-divider {
+    display: block;
+  }
+  .navbar > .container .navbar-brand,
+  .container > .navbar .navbar-brand {
+    margin-left: -0.75rem;
+  }
+  .navbar > .container .navbar-menu,
+  .container > .navbar .navbar-menu {
+    margin-right: -0.75rem;
+  }
+  .navbar.is-fixed-bottom-desktop, .navbar.is-fixed-top-desktop {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30;
+  }
+  .navbar.is-fixed-bottom-desktop {
+    bottom: 0;
+  }
+  .navbar.is-fixed-bottom-desktop.has-shadow {
+    box-shadow: 0 -2px 3px rgba(0, 0, 0, 0.1);
+  }
+  .navbar.is-fixed-top-desktop {
+    top: 0;
+  }
+  html.has-navbar-fixed-top-desktop,
+  body.has-navbar-fixed-top-desktop {
+    padding-top: 3.25rem;
+  }
+  html.has-navbar-fixed-bottom-desktop,
+  body.has-navbar-fixed-bottom-desktop {
+    padding-bottom: 3.25rem;
+  }
+  html.has-spaced-navbar-fixed-top,
+  body.has-spaced-navbar-fixed-top {
+    padding-top: 5.25rem;
+  }
+  html.has-spaced-navbar-fixed-bottom,
+  body.has-spaced-navbar-fixed-bottom {
+    padding-bottom: 5.25rem;
+  }
+  a.navbar-item.is-active, .table-of-progress .step :hover a.navbar-item.number, .table-of-progress .step :hover a.navbar-item.is-active,
+  .navbar-link.is-active,
+  .table-of-progress .step :hover .navbar-link.number,
+  .table-of-progress .step :hover .navbar-link.is-active {
+    color: rgb(51, 51, 51);
+  }
+  a.navbar-item.is-active:not(:focus):not(:hover), .table-of-progress .step :hover a.navbar-item.number:not(:focus):not(:hover),
+  .navbar-link.is-active:not(:focus):not(:hover),
+  .table-of-progress .step :hover .navbar-link.number:not(:focus):not(:hover) {
+    background-color: transparent;
+  }
+  .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link, .table-of-progress .step :hover .navbar-item.has-dropdown.number .navbar-link {
+    background-color: transparent;
+  }
+}
+.hero.is-fullheight-with-navbar {
+  min-height: calc(100vh - 3.25rem);
+}
+
+.navbar {
+  padding: 2rem;
+}
+.navbar .logo {
+  height: 46px;
+}
+.navbar .navbar-burger span {
+  height: 2px;
+}
+.navbar .navbar-burger {
+  width: 3.25rem;
+}
+.navbar .navbar-link {
+  text-decoration: none;
+}
+.navbar .navbar-end .navbar-item {
+  font-family: "Roboto Condensed", sans-serif;
+  font-size: 1.25rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  line-height: 1.5;
+  letter-spacing: 2%;
+}
+.navbar .navbar-end .navbar-item .icon {
+  margin-left: 0.5rem;
+}
+.navbar .navbar-end > .navbar-item {
+  margin-left: 2.5rem;
+}
+.navbar .navbar-end .navbar-item:hover {
+  text-decoration: none;
+  color: rgb(51, 51, 51);
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .navbar .navbar-end .navbar-item {
+    margin-left: 0;
+    font-size: 1.15rem;
+  }
+}
+.navbar.small {
+  padding: 1rem;
+}
+.navbar.small .logo {
+  height: 42px;
+}
+.navbar.small .navbar-menu {
+  margin-right: 20rem;
+}
+.navbar.small .navbar-menu.is-active, .navbar.small .table-of-progress .step :hover .navbar-menu.number, .table-of-progress .step :hover .navbar.small .navbar-menu.number {
+  margin-right: 0;
+}
+.navbar.is-compact {
+  height: 72px;
+  display: flex;
+}
+.navbar.is-compact .logo {
+  height: 36px;
+}
+.navbar.is-compact .navbar-end .navbar-item {
+  font-family: "Source Sans Pro", sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.navbar.is-compact .navbar-end > .navbar-item {
+  margin-left: 1rem;
+}
+@media screen and (max-width: 768px) {
+  .navbar.is-compact .navbar-end {
+    display: flex;
+    align-items: stretch;
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+  .navbar.is-compact .navbar-item {
+    display: flex;
+    align-items: center;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .navbar.is-compact .navbar-end {
+    display: flex;
+    align-items: stretch;
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+  .navbar.is-compact .navbar-item {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.main-footer {
+  background-color: rgb(0, 0, 0);
+  color: rgb(255, 255, 255);
+  padding: 2.5rem 0;
+}
+.main-footer a {
+  color: rgb(5, 181, 218);
+}
+.main-footer a:hover {
+  color: rgb(5, 181, 218);
+  text-decoration: underline;
+}
+.main-footer a.social:hover {
+  text-decoration: none;
+}
+.main-footer .main-logo {
+  display: block;
+}
+.main-footer .main-logo svg {
+  width: 13rem;
+}
+.main-footer address {
+  font-style: normal;
+}
+.main-footer .footer-navigation .menu li {
+  display: inline-block;
+}
+.main-footer .footer-navigation .menu li:first-child .menu-item {
+  padding-left: 0;
+}
+.main-footer .footer-navigation .menu li .menu-item {
+  display: block;
+  padding: 1rem;
+  font-size: 1.43rem;
+  font-style: normal;
+  font-weight: bold;
+}
+.main-footer .subscription h5 {
+  margin-bottom: 1rem;
+  color: rgb(255, 255, 255);
+}
+.main-footer .subscription .newsletter {
+  display: flex;
+  width: 70%;
+}
+.main-footer .subscription .newsletter .input {
+  background-color: transparent;
+  border-color: rgb(118, 118, 118);
+  color: rgb(118, 118, 118);
+}
+.main-footer .subscription .newsletter .input::placeholder {
+  color: rgb(118, 118, 118);
+  opacity: 0.8;
+}
+.main-footer .subscription .newsletter .button {
+  margin-left: -1rem;
+  border: none;
+  background-color: rgb(118, 118, 118);
+  color: rgb(255, 255, 255);
+}
+.main-footer .subscription .newsletter .button:hover {
+  background-color: #909090;
+}
+.main-footer .donate-section h5 {
+  color: rgb(255, 255, 255);
+}
+.main-footer .donate-section .donate {
+  margin-top: 1.5rem;
+  color: rgb(0, 0, 0);
+}
+.main-footer .donate-section .donate svg {
+  margin-right: 1rem;
+  width: 2rem;
+  height: 2rem;
+}
+@media screen and (min-width: 769px), print {
+  .main-footer {
+    padding: 1.5rem;
+  }
+  .main-footer .footer-navigation .menu {
+    display: flex;
+  }
+}
+@media screen and (max-width: 768px) {
+  .main-footer {
+    padding: 1rem;
+  }
+  .main-footer .footer-navigation {
+    margin-bottom: 1rem;
+  }
+  .main-footer .footer-navigation .menu li {
+    display: block;
+  }
+  .main-footer .footer-navigation .menu li .menu-item {
+    padding-left: 0;
+  }
+}
+
+.github-corner {
+  position: absolute;
+  top: 0;
+}
+.github-corner.is-left-aligned {
+  left: 0;
+  transform: scaleX(-1);
+}
+.github-corner:not(.is-left-aligned) {
+  right: 0;
+}
+.github-corner.is-inverted {
+  color: rgb(0, 0, 0);
+}
+.github-corner.is-inverted svg {
+  fill: rgb(255, 255, 255);
+}
+.github-corner.is-inverted:hover {
+  color: rgb(0, 0, 0);
+}
+.github-corner:not(.is-inverted) {
+  color: rgb(255, 255, 255);
+}
+.github-corner:not(.is-inverted) svg {
+  fill: rgb(0, 0, 0);
+}
+.github-corner:not(.is-inverted):hover {
+  color: rgb(255, 255, 255);
+}
+
+.locale {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-family: "Source Sans Pro", sans-serif;
+}
+.locale .select {
+  margin-left: 0.5rem;
+}
+.locale .icon {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  padding-left: 10px;
+}
+
+.image {
+  position: relative;
+  overflow: hidden;
+}
+.image img {
+  display: block;
+  width: 100%;
+}
+.image .image-title,
+.image .image-icons,
+.image .bookmark-icon {
+  transition: transform 0.2s linear;
+  position: absolute;
+}
+.image .image-title {
+  transform: translateY(100%);
+  left: 0;
+  bottom: 0;
+  font-weight: 600;
+}
+.image .image-title.is-ellipsised:not(:hover) {
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.image .image-icons {
+  transform: translateY(-100%);
+  left: 0;
+  top: 0;
+  font-size: 1.625rem;
+}
+.image .bookmark-icon {
+  right: 0;
+  top: 0;
+  line-height: 1;
+  transform: translateY(-100%);
+}
+.image:hover .image-title,
+.image:hover .image-icons,
+.image:hover .bookmark-icon {
+  transform: translateY(0%);
+}
+.image.is-compact .image-icons {
+  font-size: 1.3rem;
+}
+.image.is-selected {
+  border: 6px solid rgb(239, 190, 0);
+}
+
+.image {
+  display: block;
+  position: relative;
+}
+.image img {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+.image img.is-rounded, .image img.profile {
+  border-radius: 290486px;
+}
+.image.is-fullwidth {
+  width: 100%;
+}
+.image.is-square img,
+.image.is-square .has-ratio, .image.is-1by1 img,
+.image.is-1by1 .has-ratio, .image.is-5by4 img,
+.image.is-5by4 .has-ratio, .image.is-4by3 img,
+.image.is-4by3 .has-ratio, .image.is-3by2 img,
+.image.is-3by2 .has-ratio, .image.is-5by3 img,
+.image.is-5by3 .has-ratio, .image.is-16by9 img,
+.image.is-16by9 .has-ratio, .image.is-2by1 img,
+.image.is-2by1 .has-ratio, .image.is-3by1 img,
+.image.is-3by1 .has-ratio, .image.is-4by5 img,
+.image.is-4by5 .has-ratio, .image.is-3by4 img,
+.image.is-3by4 .has-ratio, .image.is-2by3 img,
+.image.is-2by3 .has-ratio, .image.is-3by5 img,
+.image.is-3by5 .has-ratio, .image.is-9by16 img,
+.image.is-9by16 .has-ratio, .image.is-1by2 img,
+.image.is-1by2 .has-ratio, .image.is-1by3 img,
+.image.is-1by3 .has-ratio {
+  height: 100%;
+  width: 100%;
+}
+.image.is-square, .image.is-1by1 {
+  padding-top: 100%;
+}
+.image.is-5by4 {
+  padding-top: 80%;
+}
+.image.is-4by3 {
+  padding-top: 75%;
+}
+.image.is-3by2 {
+  padding-top: 66.6666%;
+}
+.image.is-5by3 {
+  padding-top: 60%;
+}
+.image.is-16by9 {
+  padding-top: 56.25%;
+}
+.image.is-2by1 {
+  padding-top: 50%;
+}
+.image.is-3by1 {
+  padding-top: 33.3333%;
+}
+.image.is-4by5 {
+  padding-top: 125%;
+}
+.image.is-3by4 {
+  padding-top: 133.3333%;
+}
+.image.is-2by3 {
+  padding-top: 150%;
+}
+.image.is-3by5 {
+  padding-top: 166.6666%;
+}
+.image.is-9by16 {
+  padding-top: 177.7777%;
+}
+.image.is-1by2 {
+  padding-top: 200%;
+}
+.image.is-1by3 {
+  padding-top: 300%;
+}
+.image.is-16x16 {
+  height: 16px;
+  width: 16px;
+}
+.image.is-24x24 {
+  height: 24px;
+  width: 24px;
+}
+.image.is-32x32 {
+  height: 32px;
+  width: 32px;
+}
+.image.is-48x48 {
+  height: 48px;
+  width: 48px;
+}
+.image.is-64x64 {
+  height: 64px;
+  width: 64px;
+}
+.image.is-96x96 {
+  height: 96px;
+  width: 96px;
+}
+.image.is-128x128 {
+  height: 128px;
+  width: 128px;
+}
+
+.image .profile {
+  border: solid 0.1875em rgb(51, 51, 51);
+  min-width: 60px;
+  object-fit: cover;
+  height: 100%;
+}
+
+.content li + li {
+  margin-top: 0.25em;
+}
+.content p:not(:last-child),
+.content dl:not(:last-child),
+.content ol:not(:last-child),
+.content ul:not(:last-child),
+.content blockquote:not(:last-child),
+.content pre:not(:last-child),
+.content table:not(:last-child) {
+  margin-bottom: 1em;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  color: hsl(0, 0%, 21%);
+  font-weight: 600;
+  line-height: 1.125;
+}
+.content h1 {
+  font-size: 2em;
+  margin-bottom: 0.5em;
+}
+.content h1:not(:first-child) {
+  margin-top: 1em;
+}
+.content h2 {
+  font-size: 1.75em;
+  margin-bottom: 0.5714em;
+}
+.content h2:not(:first-child) {
+  margin-top: 1.1428em;
+}
+.content h3 {
+  font-size: 1.5em;
+  margin-bottom: 0.6666em;
+}
+.content h3:not(:first-child) {
+  margin-top: 1.3333em;
+}
+.content h4 {
+  font-size: 1.25em;
+  margin-bottom: 0.8em;
+}
+.content h5 {
+  font-size: 1.125em;
+  margin-bottom: 0.8888em;
+}
+.content h6 {
+  font-size: 1em;
+  margin-bottom: 1em;
+}
+.content blockquote {
+  background-color: hsl(0, 0%, 96%);
+  border-left: 5px solid rgb(245, 245, 245);
+  padding: 1.25em 1.5em;
+}
+.content ol {
+  list-style-position: outside;
+  margin-left: 2em;
+  margin-top: 1em;
+}
+.content ol:not([type]) {
+  list-style-type: decimal;
+}
+.content ol:not([type]).is-lower-alpha {
+  list-style-type: lower-alpha;
+}
+.content ol:not([type]).is-lower-roman {
+  list-style-type: lower-roman;
+}
+.content ol:not([type]).is-upper-alpha {
+  list-style-type: upper-alpha;
+}
+.content ol:not([type]).is-upper-roman {
+  list-style-type: upper-roman;
+}
+.content ul {
+  list-style: disc outside;
+  margin-left: 2em;
+  margin-top: 1em;
+}
+.content ul ul {
+  list-style-type: circle;
+  margin-top: 0.5em;
+}
+.content ul ul ul {
+  list-style-type: square;
+}
+.content dd {
+  margin-left: 2em;
+}
+.content figure {
+  margin-left: 2em;
+  margin-right: 2em;
+  text-align: center;
+}
+.content figure:not(:first-child) {
+  margin-top: 2em;
+}
+.content figure:not(:last-child) {
+  margin-bottom: 2em;
+}
+.content figure img {
+  display: inline-block;
+}
+.content figure figcaption {
+  font-style: italic;
+}
+.content pre {
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  padding: 1.25em 1.5em;
+  white-space: pre;
+  word-wrap: normal;
+}
+.content sup,
+.content sub {
+  font-size: 75%;
+}
+.content table {
+  width: 100%;
+}
+.content table td,
+.content table th {
+  border: 1px solid rgb(245, 245, 245);
+  border-width: 0 0 1px;
+  padding: 0.5em 0.75em;
+  vertical-align: top;
+}
+.content table th {
+  color: hsl(0, 0%, 21%);
+}
+.content table th:not([align]) {
+  text-align: inherit;
+}
+.content table thead td,
+.content table thead th {
+  border-width: 0 0 2px;
+  color: hsl(0, 0%, 21%);
+}
+.content table tfoot td,
+.content table tfoot th {
+  border-width: 2px 0 0;
+  color: hsl(0, 0%, 21%);
+}
+.content table tbody tr:last-child td,
+.content table tbody tr:last-child th {
+  border-bottom-width: 0;
+}
+.content .tabs li + li {
+  margin-top: 0;
+}
+.content.is-small {
+  font-size: 0.8rem;
+}
+.content.is-medium {
+  font-size: 1.12rem;
+}
+.content.is-large {
+  font-size: 1.43rem;
+}
+
+body {
+  color: rgb(51, 51, 51);
+}
+
+a, a:hover {
+  color: rgb(60, 92, 153);
+}
+
+.breadcrumb a, .breadcrumb a:hover {
+  color: rgb(60, 92, 153);
+}
+
+.button.case {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: white;
+}
+.button.case:hover {
+  background-color: rgb(255, 105, 51);
+  border-color: rgb(255, 105, 51);
+}
+.button.case.tag {
+  background-color: white;
+  color: rgb(118, 118, 118);
+}
+.button.case.tag.outline {
+  border-color: rgb(226, 54, 0);
+  text-decoration: none;
+}
+.button.case.tag:hover, .button.case.tag.selected {
+  background-color: rgb(226, 54, 0);
+  border-color: rgb(226, 54, 0);
+  color: white;
+}
+.button.scholarship {
+  background-color: rgb(0, 131, 0);
+  border-color: rgb(0, 131, 0);
+  color: white;
+}
+.button.scholarship:hover {
+  background-color: rgb(0, 184, 80);
+  border-color: rgb(0, 184, 80);
+}
+.button.scholarship.tag {
+  background-color: white;
+  color: rgb(118, 118, 118);
+}
+.button.scholarship.tag.outline {
+  border-color: rgb(0, 131, 0);
+  text-decoration: none;
+}
+.button.scholarship.tag:hover, .button.scholarship.tag.selected {
+  background-color: rgb(0, 131, 0);
+  border-color: rgb(0, 131, 0);
+  color: white;
+}
+.button.is-delete {
+  color: rgb(226, 54, 0);
+  font-size: 1rem;
+  margin-top: 2rem;
+  padding: 0;
+  width: 100%;
+}
+.button.is-delete:hover {
+  color: white;
+}
+.button.is-delete .icon {
+  padding: 0.25rem 0;
+}
+
+@media (max-width: 768px) {
+  .button.is-delete {
+    margin-top: 0;
+  }
+}
+.card.entry-post.link.no-border {
+  max-width: 600px;
+}
+.card.entry-post.link.no-border a .card-content.has-bottom-link {
+  padding: 0 0 3rem 0;
+}
+.card.entry-post.link.no-border a:hover.has-background-tomato {
+  background-color: rgb(255, 105, 51) !important;
+}
+.card.entry-post.link.no-border a:hover.has-background-forest-green {
+  background-color: rgb(0, 184, 80) !important;
+}
+
+.card-eyebrow {
+  color: rgb(51, 51, 51);
+  font-family: "Roboto Condensed", sans-serif;
+  font-size: 1.43rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  line-height: 1.3;
+  letter-spacing: 0.02rem;
+}
+
+.cases, .scholarships {
+  padding-top: 1.5rem;
+  padding-bottom: 1rem;
+}
+
+.columns.submit {
+  background-color: rgb(245, 245, 245);
+  margin-bottom: 0;
+}
+
+.container > .navbar .navbar-brand {
+  margin-left: 0;
+}
+
+@media (max-width: 650px) {
+  .case-holder {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 1rem;
+  }
+}
+
+.contribute {
+  padding-top: 2rem;
+  padding-bottom: 4rem;
+}
+.contribute-card {
+  float: right;
+  max-width: 380px;
+  margin-right: 1.9rem;
+}
+@media (max-width: 1023px) {
+  .contribute-card {
+    max-width: 300px;
+  }
+}
+@media (max-width: 650px) {
+  .contribute-card {
+    float: none;
+    margin: 0 2rem;
+    max-width: unset;
+  }
+}
+
+.control.has-icons-left .icon {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  color: rgb(216, 216, 216);
+}
+
+.details,
+.faqs {
+  padding-top: 4rem;
+  padding-bottom: 2.5rem;
+}
+
+.errorlist {
+  color: rgb(226, 54, 0);
+  font-size: 0.9rem;
+}
+
+.explore {
+  padding-top: 4rem;
+  padding-bottom: 2rem;
+}
+
+.explore .container, .contribute .container, .cases .container, .scholarships .container, .details .container, .faqs .container {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.faq__content {
+  border-bottom: 2px solid rgb(216, 216, 216);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+}
+.faq__head {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.faq__head::after {
+  font-family: "Vocabulary Icons";
+  font-size: 1.5rem;
+  content: "\e906";
+  color: rgb(51, 51, 51);
+  margin: 0 1rem;
+}
+.faq__head.expanded::after {
+  content: "\e904";
+}
+.faq__body {
+  padding-right: 1.5rem;
+}
+.faq__body ul {
+  list-style-type: disc;
+  list-style-position: inside;
+  margin-left: 15px;
+}
+
+.form.case, .form.scholarship {
+  margin: 1.5rem 2rem;
+}
+.form.case .field, .form.scholarship .field {
+  margin-bottom: 1.5rem;
+}
+.form.case .input, .form.case .select, .form.scholarship .input, .form.scholarship .select {
+  margin-top: 0.5rem;
+}
+.form.case h4, .form.scholarship h4 {
+  margin-bottom: 0.5rem;
+}
+.form.case hr, .form.scholarship hr {
+  margin: 1rem 0;
+  background-color: rgb(216, 216, 216);
+}
+
+.hero {
+  background-color: rgb(245, 245, 245);
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+.hero.case, .hero.scholarship, .hero.faq {
+  padding-top: 2.5rem;
+}
+.hero.case {
+  box-shadow: inset 0px 6px 0px rgb(226, 54, 0);
+}
+.hero.scholarship {
+  box-shadow: inset 0px 6px 0px rgb(0, 131, 0);
+}
+.hero.submit {
+  background-color: white;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+.hero-title, .hero-description, .hero .breadcrumb {
+  padding: 0 2rem;
+}
+.hero-description.body-big {
+  max-width: 708px;
+  padding-top: 0.5rem;
+}
+.hero-description.body-normal, .card.blog-entry .blog-content .hero-description.blog-author, .card.blog-entry .blog-content .hero-description.excerpt, .hero-description.table, .hero-description.sidebar-menu, .hero-description.table-of-contents, .table-of-progress .step .hero-description.link {
+  max-width: 800px;
+}
+
+.links-list {
+  list-style-type: circle;
+  overflow-wrap: break-word;
+}
+.links-list a {
+  color: rgb(60, 92, 153);
+}
+
+.required {
+  color: darkred;
+  font-weight: bold;
+}
+
+.search-input {
+  width: 100%;
+}
+
+.tags-filter {
+  color: rgb(60, 92, 153);
+  cursor: pointer;
+  user-select: none;
+}
+.tags-filter #tags-hide,
+.tags-filter #tags-show {
+  white-space: nowrap;
+  gap: 0.25rem;
+}
+
+/* Vocabulary overrides */
+.navbar .navbar-burger {
+  height: 40px;
+}
+
+body > header .explore-panel aside h2 {
+  margin: revert;
+  color: white;
+  font-size: 1.5em;
+  text-transform: none;
+}
+
+body > header .explore-panel aside p {
+  margin: revert;
+}
+
+body > header .explore-panel nav ul li p {
+  margin: revert;
+}

--- a/webpack/sass/styles.scss
+++ b/webpack/sass/styles.scss
@@ -326,3 +326,19 @@ a, a:hover {
 .navbar .navbar-burger {
   height: 40px;
 }
+
+body > header .explore-panel aside h2{
+  margin: revert;
+  
+  color: white;
+  font-size: 1.5em;
+  text-transform: none;
+}
+
+body > header .explore-panel aside p{
+  margin: revert;
+}
+
+body > header .explore-panel nav ul li p{
+  margin:revert;
+}


### PR DESCRIPTION
## Fixes
- Fixes #195 by @Netacci

## Description
Following a recent merge [#222](https://github.com/creativecommons/legaldb/pull/222) , to the `vocab-refresh `branch to implement current _**Vocabulary Design System**_ in the Header region , the Legal Database' current `.explore-panel` design does not fully align with the design choices outlined in `vocabulary.css` , leading to visual inconsistencies across the site.

## Technical details
To address style conflicts, I added specific styles to targeted HTML tags within their respective classes. By using class-specific selectors (e.g `body > header .explore-panel aside h2` ), I ensured that the styles apply directly to the intended elements, overriding any conflicting rules from other stylesheets or general selectors. This approach helped maintain consistent styling across components without affecting unrelated elements. 
## Tests

1. Open the Legal Database website.
2. Click on Explore CC.
3. See changes.

## Screenshots

Current `explore-panel` view : 

<img width="896" alt="Screenshot 2024-11-07 at 7 18 31 PM" src="https://github.com/user-attachments/assets/a0ec7ae3-07b4-4171-bbee-d54ab31c3050">

After resolving style conflicts : 

<img width="896" alt="Screenshot 2024-11-07 at 7 17 56 PM" src="https://github.com/user-attachments/assets/365bde5b-6644-4f75-96f3-ef1b51a0e94a">


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
