### PR TITLE
Add debug toolbar and enable it in dev

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 black = "*"
+django-debug-toolbar = "*"
 factory-boy = "*"
 flake8 = "*"
 isort = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31e062168424a757caa9db7d9c91c2ca791e9b2a609f8be0080cfb554a241caa"
+            "sha256": "181eee74784ce0ce0e20f55784b06951da0dc3b7041e63af01e33480f88a072b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -770,6 +770,14 @@
         }
     },
     "develop": {
+        "asgiref": {
+            "hashes": [
+                "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47",
+                "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.8.1"
+        },
         "black": {
             "hashes": [
                 "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f",
@@ -806,6 +814,24 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "django": {
+            "hashes": [
+                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
+                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.16"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044",
+                "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.4.6"
         },
         "factory-boy": {
             "hashes": [
@@ -913,6 +939,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:9e37b35e16d1cc652a2545f0997c1deb23ea28fa1f3eefe609eee3063c3b105f",
+                "sha256:e99bc85c78160918c3e1d9230834ab8d80fc06c59d03f8db2618f65f65dda55e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.5.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/caselaw/settings.py
+++ b/caselaw/settings.py
@@ -51,6 +51,11 @@ INSTALLED_APPS = [
     "taggit",
     "widget_tweaks",
 ]
+# Debug toolbar
+if DEBUG:
+    INSTALLED_APPS += [
+        "debug_toolbar",
+    ]
 
 MIDDLEWARE = [
     # SecurityMiddleware must be listed before other middleware
@@ -65,6 +70,11 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
+# Debug toolbar
+if DEBUG:
+    MIDDLEWARE += [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    ]
 
 ROOT_URLCONF = "caselaw.urls"
 
@@ -230,3 +240,7 @@ if SECURE_SSL_REDIRECT:
 
 # See https://devcenter.heroku.com/articles/deploying-python
 django_heroku.settings(locals(), logging=False)
+
+# Debug toolbar
+if DEBUG:
+    DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG}

--- a/caselaw/urls.py
+++ b/caselaw/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 
 # Third-party
+import debug_toolbar
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path, re_path
@@ -30,4 +31,5 @@ urlpatterns = [
 # URLs with language code prefixes
 urlpatterns += i18n_patterns(
     path("", include("legal_db.urls")),
+    path("__debug__/", include(debug_toolbar.urls)),
 )

--- a/manage.py
+++ b/manage.py
@@ -43,4 +43,3 @@ if __name__ == "__main__":
         print("ERROR (1) Unhandled exception:", file=sys.stderr)
         print(traceback.print_exc(), file=sys.stderr)
         sys.exit(1)
-        


### PR DESCRIPTION
## Description
Add debug toolbar and enable it in dev

## Technical details
Changes to Python modules:
```diff
--- piplist.old	2024-11-26 11:22:16
+++ piplist.new	2024-11-26 11:22:16
@@ -12,6 +12,7 @@
 django-appconf       1.0.6
 django-compressor    4.5.1
 django-countries     7.6.1
+django-debug-toolbar 4.4.6
 django-heroku        0.3.1
 django-libsass       0.9
 django-markdownx     4.0.7
@@ -19,7 +20,7 @@
 django-taggit        4.0.0
 django-widget-tweaks 1.5.0
 factory_boy          3.3.1
-Faker                30.8.2
+Faker                33.0.0
 filelock             3.16.1
 flake8               7.1.1
 future               1.0.0
@@ -30,26 +31,28 @@
 Markdown             3.7
 mccabe               0.7.0
 mypy-extensions      1.0.0
-packaging            24.1
+packaging            24.2
 parsimonious         0.10.0
 pathspec             0.12.1
 pillow               11.0.0
 pip                  24.3.1
-pipenv               2024.3.1
+pipenv               2024.4.0
 platformdirs         4.3.6
 polib                1.2.0
 psycopg2             2.9.10
 pycodestyle          2.12.1
 pyflakes             3.2.0
+Pygments             2.18.0
 pyseeyou             1.0.2
 python-dateutil      2.9.0.post0
+PyYAML               6.0.2
 rcssmin              1.1.2
-regex                2024.9.11
+regex                2024.11.6
 requests             2.32.3
 rjsmin               1.2.2
-setuptools           75.3.0
+setuptools           75.5.0
 six                  1.16.0
-sqlparse             0.5.1
+sqlparse             0.5.2
 toolz                1.0.0
 transifex-python     3.5.0
 typing_extensions    4.12.2
```

## Tests
```shell
./bin/test.sh 
```
```
# Django collectstatic                                                  11:23:49 

0 static files copied to '/legaldb/staticfiles', 488 unmodified, 533 post-processed.

# Django test                                                           11:23:51 
Found 13 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
2024-11-26 19:23:52 [190] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=241 funcname=log_response Not Found: /en/cases/1/
.......2024-11-26 19:23:54 [190] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=241 funcname=log_response Not Found: /en/scholarship/1/
......
----------------------------------------------------------------------
Ran 13 tests in 2.507s

OK
Destroying test database for alias 'default'...
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
