### PR TITLE
improve handling of DEBUG and debug_toolbar

### DIFF
--- a/caselaw/urls.py
+++ b/caselaw/urls.py
@@ -15,11 +15,15 @@ Including another URLconf
 """
 
 # Third-party
-import debug_toolbar
+from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.i18n import set_language
+
+if settings.DEBUG:
+    # Third-party
+    import debug_toolbar
 
 # Non-translated URLs (admin and markdownx)
 urlpatterns = [
@@ -31,5 +35,8 @@ urlpatterns = [
 # URLs with language code prefixes
 urlpatterns += i18n_patterns(
     path("", include("legal_db.urls")),
-    path("__debug__/", include(debug_toolbar.urls)),
 )
+if settings.DEBUG:
+    urlpatterns += i18n_patterns(
+        path("__debug__/", include(debug_toolbar.urls)),
+    )


### PR DESCRIPTION
## Fixes
- ‼️ fix bad deploy https://github.com/creativecommons/legaldb/pull/272#issuecomment-2502039925

## Description
improve handling of DEBUG and debug_toolbar

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
```shell
./bin/test.sh
```
```
# Django collectstatic                                                  14:15:18 

0 static files copied to '/legaldb/staticfiles', 488 unmodified, 533 post-processed.

# Django test                                                           14:15:20 
Found 13 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
2024-11-26 22:15:22 [52] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=241 funcname=log_response Not Found: /en/cases/1/
.......2024-11-26 22:15:23 [52] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=241 funcname=log_response Not Found: /en/scholarship/1/
......
----------------------------------------------------------------------
Ran 13 tests in 1.949s

OK
Destroying test database for alias 'default'...
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
