### PR TITLE
Replace distutils.util.strtobool as it no long exists in Python 3.12

### DIFF
--- a/caselaw/settings.py
+++ b/caselaw/settings.py
@@ -11,11 +11,31 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 # Standard library
 import os
 import sys
-from distutils.util import strtobool
 
 # Third-party
 import django_heroku
 from django.utils.translation import gettext_lazy as _
+
+
+# Based on Python 3.11.2 distutils.util.strtobool
+def string_to_bool(string_value):
+    """Convert a string to boolean.
+
+    True values are  'y', 'yes', 't', 'true',  'on',  and '1'
+    False values are 'n', 'no',  'f', 'false', 'off', and '0'.
+
+    Raises ValueError if 'string_value' is anything else.
+    """
+    string_value = str(string_value).lower()
+    if string_value in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif string_value in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(
+            "invalid string representation of boolean value {string_value}"
+        )
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -44,8 +64,8 @@ if (
     and "publish" not in sys.argv
     and "test" not in sys.argv
 ):
-    DEBUG = bool(
-        strtobool(str(os.environ.get("DJANGO_DEBUG_ENABLED", default=False)))
+    DEBUG = string_to_bool(
+        os.environ.get("DJANGO_DEBUG_ENABLED", default=False)
     )
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
@@ -250,21 +270,22 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
 
-COMPRESS_ENABLED = bool(
-    strtobool(str(os.environ.get("DJANGO_COMPRESS_ENABLED", True)))
+COMPRESS_ENABLED = string_to_bool(
+    os.environ.get("DJANGO_COMPRESS_ENABLED", True)
 )
 
-COMPRESS_OFFLINE = bool(
-    strtobool(str(os.environ.get("DJANGO_COMPRESS_OFFLINE", True)))
+COMPRESS_OFFLINE = string_to_bool(
+    os.environ.get("DJANGO_COMPRESS_OFFLINE", True)
 )
 
 LIBSASS_OUTPUT_STYLE = os.environ.get("DJANGO_LIBSASS_STYLE", "compressed")
 
 
 # TLS/SSL (HTTPS)
-SECURE_SSL_REDIRECT = bool(
-    strtobool(str(os.environ.get("DJANGO_SECURE_SSL_REDIRECT", True)))
+SECURE_SSL_REDIRECT = string_to_bool(
+    os.environ.get("DJANGO_SECURE_SSL_REDIRECT", True)
 )
+
 if SECURE_SSL_REDIRECT:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/caselaw/settings.py
+++ b/caselaw/settings.py
@@ -33,7 +33,7 @@ def string_to_bool(string_value):
         return False
     else:
         raise ValueError(
-            "invalid string representation of boolean value {string_value}"
+            f"invalid string representation of boolean value: '{string_value}'"
         )
 
 


### PR DESCRIPTION
## Fixes
Heroku deployment error
<details>
<summary>Deployment command output excerpt</summary>

```python
remote: Building source:
remote: 
remote: -----> Building on the Heroku-24 stack
remote: -----> Using buildpack: heroku/python
remote: -----> Python app detected
remote: -----> Using Python 3.12 specified in Pipfile.lock
remote: -----> Discarding cache since:
remote:        - The Pipenv version has changed from 2024.0.1 to 2025.0.4
remote:        - The legacy SQLite3 headers and CLI binary need to be uninstalled
remote: -----> Installing Python 3.12.11
remote: -----> Installing Pipenv 2025.0.4
remote: -----> Installing dependencies using 'pipenv install --deploy'
remote:        Installing dependencies from Pipfile.lock (08c160)...
remote: -----> $ python manage.py collectstatic --noinput
remote:        ERROR (1) Unhandled exception:
remote:        Traceback (most recent call last):
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 255, in fetch_command
remote:            app_name = commands[subcommand]
remote:                       ~~~~~~~~^^^^^^^^^^^^
remote:        KeyError: 'collectstatic'
remote:        During handling of the above exception, another exception occurred:
remote:        Traceback (most recent call last):
remote:          File "/tmp/build_becbb144/manage.py", line 32, in <module>
remote:            main()
remote:          File "/tmp/build_becbb144/manage.py", line 27, in main
remote:            execute_from_command_line(sys.argv)
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
remote:            utility.execute()
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
remote:            self.fetch_command(subcommand).run_from_argv(self.argv)
remote:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/core/management/__init__.py", line 262, in fetch_command
remote:            settings.INSTALLED_APPS
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/conf/__init__.py", line 102, in __getattr__
remote:            self._setup(name)
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/conf/__init__.py", line 89, in _setup
remote:            self._wrapped = Settings(settings_module)
remote:                            ^^^^^^^^^^^^^^^^^^^^^^^^^
remote:          File "/app/.heroku/python/lib/python3.12/site-packages/django/conf/__init__.py", line 217, in __init__
remote:            mod = importlib.import_module(self.SETTINGS_MODULE)
remote:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
remote:          File "/app/.heroku/python/lib/python3.12/importlib/__init__.py", line 90, in import_module
remote:            return _bootstrap._gcd_import(name[level:], package, level)
remote:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
remote:          File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
remote:          File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
remote:          File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
remote:          File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
remote:          File "<frozen importlib._bootstrap_external>", line 999, in exec_module
remote:          File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
remote:          File "/tmp/build_becbb144/caselaw/settings.py", line 14, in <module>
remote:            from distutils.util import strtobool
remote:        ModuleNotFoundError: No module named 'distutils'
remote:        None
remote: 
remote: 
remote:  !     Error: Unable to generate Django static files.
remote:  !     
remote:  !     The 'python manage.py collectstatic --noinput' Django
remote:  !     management command to generate static files failed.
remote:  !     
remote:  !     See the traceback above for details.
remote:  !     
remote:  !     You may need to update application code to resolve this error.
remote:  !     Or, you can disable collectstatic for this application:
remote:  !     
remote:  !        $ heroku config:set DISABLE_COLLECTSTATIC=1
remote:  !     
remote:  !     https://devcenter.heroku.com/articles/django-assets
remote: 
remote:  !     Push rejected, failed to compile Python app.
remote: 
remote:  !     Push failed
```

</details>

## Description
Replace `distutils.util.strtobool` as it no long exists in Python 3.12

## Technical details
- [python - What is setuptool's alternative to (the deprecated) distutils `strtobool`? - Stack Overflow](https://stackoverflow.com/questions/77941994/what-is-setuptools-alternative-to-the-deprecated-distutils-strtobool)

## Tests
## Unit tests
command:
```shell
./bin/test.sh
```
output:
```
# Django collectstatic                                                  15:51:46 

0 static files copied to '/legaldb/staticfiles', 488 unmodified, 533 post-processed.

# Django test                                                           15:51:47 
Found 13 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
2025-09-16 13:51:49 [96] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=246 funcname=log_response Not Found: /en/cases/1/
.......2025-09-16 13:51:50 [96] [WARNING] pathname=/usr/local/lib/python3.12/site-packages/django/utils/log.py lineno=246 funcname=log_response Not Found: /en/scholarship/1/
......
----------------------------------------------------------------------
Ran 13 tests in 1.810s

OK
Destroying test database for alias 'default'...
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
